### PR TITLE
[Feat] 모임 서버 생성 API / 서버 정보 조회 API

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' //AWS S3
 }
 
 tasks.named('test') {

--- a/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
@@ -16,6 +16,8 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.channel.entity.Channel;
@@ -25,6 +27,8 @@ import org.bookwoori.core.domain.server.entity.Server;
 @Table(name = "category")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Category {
 
     @Id
@@ -33,8 +37,7 @@ public class Category {
     private Long categoryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "server_id", updatable = false)
-    @NotNull
+    @JoinColumn(name = "server_id")
     private Server server;
 
     @Column(name = "name")
@@ -48,6 +51,10 @@ public class Category {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "next_category_id")
     private Category nextNode;
+
+    @Column(name = "is_default")
+    @NotNull
+    private boolean isDefault;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     private List<Channel> channels = new ArrayList<>();

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
@@ -2,7 +2,9 @@ package org.bookwoori.core.domain.category.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.category.entity.Category;
 import org.bookwoori.core.domain.category.repository.CategoryRepository;
+import org.bookwoori.core.domain.server.entity.Server;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,4 +12,13 @@ import org.springframework.stereotype.Service;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+
+    public Category makeDefaultCategory(Server server) {
+        Category category = Category.builder()
+            .server(server)
+            .name("DEFAULT")
+            .isDefault(true)
+            .build();
+        return categoryRepository.save(category);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/entity/Channel.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/entity/Channel.java
@@ -15,6 +15,8 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.category.entity.Category;
@@ -24,6 +26,8 @@ import org.bookwoori.core.global.BaseTimeEntity;
 @Table(name = "channel")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Channel extends BaseTimeEntity {
 
     @Id
@@ -32,7 +36,7 @@ public class Channel extends BaseTimeEntity {
     private Long channelId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", updatable = false)
+    @JoinColumn(name = "category_id")
     private Category category;
 
     @Column(name = "name")
@@ -51,4 +55,10 @@ public class Channel extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "next_channel_id")
     private Channel nextNode;
+
+    public void setNextNode(Channel channel){
+        this.nextNode = channel;
+        channel.beforeNode = this;
+    }
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
@@ -1,6 +1,9 @@
 package org.bookwoori.core.domain.channel.service;
 
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.channel.entity.Channel;
+import org.bookwoori.core.domain.channel.entity.ChannelType;
 import org.bookwoori.core.domain.channel.repository.ChannelRepository;
 import org.springframework.stereotype.Service;
 
@@ -8,5 +11,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChannelService {
 
-    private ChannelRepository channelRepository;
+    private final ChannelRepository channelRepository;
+
+    public void makeDefaultChannels(Category category) {
+        Channel chatChannel = Channel.builder()
+            .category(category)
+            .name("일반")
+            .channelType(ChannelType.CHAT)
+            .build();
+        Channel voiceChannel = Channel.builder()
+            .category(category)
+            .name("일반")
+            .channelType(ChannelType.VOICE)
+            .build();
+        chatChannel.setNextNode(voiceChannel);
+        channelRepository.save(chatChannel);
+        channelRepository.save(voiceChannel);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
@@ -1,9 +1,7 @@
-package org.bookwoori.core.domain.member.entity;
+package org.bookwoori.core.domain.climbingMember.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,32 +13,34 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bookwoori.core.domain.server.entity.Server;
+import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.member.entity.Member;
 
 @Entity
-@Table(name = "server_member")
+@Table(name = "climbing_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ServerMember {
+public class ClimbingMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "server_member_id", updatable = false)
-    private Long serverMemberId;
+    @Column(name = "climbing_member_id", updatable = false)
+    private Long climbingMemberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "climbing_id", updatable = false)
+    @NotNull
+    private Climbing climbing;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", updatable = false)
     @NotNull
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "server_id")
+    @Column(name = "has_shared")
     @NotNull
-    private Server server;
+    private boolean hasShared;
 
-    @Column(name = "role")
-    @NotNull
-    @Enumerated(EnumType.STRING)
-    private ServerRole role;
-
+    @Column(name = "memo")
+    private String memo;
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -1,0 +1,8 @@
+package org.bookwoori.core.domain.climbingMember.repository;
+
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, Long> {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -1,0 +1,12 @@
+package org.bookwoori.core.domain.climbingMember.service;
+
+import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.climbingMember.repository.ClimbingMemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ClimbingMemberService {
+
+    private final ClimbingMemberRepository climbingMemberRepository;
+}

--- a/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
@@ -17,11 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
     private final MemberService memberService;
 
     @GetMapping("/success")
     public ResponseEntity<?> loginSuccess(@Valid LoginResponse loginResponse) {
         return ResponseEntity.ok(loginResponse);
     }
-    
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/dto/response/LoginResponse.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/dto/response/LoginResponse.java
@@ -3,4 +3,5 @@ package org.bookwoori.core.domain.member.dto.response;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginResponse(@NotBlank String accessToken) {
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/entity/ServerRole.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/entity/ServerRole.java
@@ -1,6 +1,0 @@
-package org.bookwoori.core.domain.member.entity;
-
-public enum ServerRole {
-    OWNER,
-    MEMBER;
-}

--- a/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
@@ -27,7 +27,9 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(() -> {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         });
-      
+    }
+
+    @Transactional(readOnly = true)
     public Member getCurrentMember() throws CustomException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Member member = memberRepository.findByKakaoId(Long.valueOf(authentication.getName()))

--- a/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
@@ -1,8 +1,12 @@
 package org.bookwoori.core.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.repository.MemberRepository;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -10,4 +14,10 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        });
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class MemberService {
+
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
@@ -33,7 +34,7 @@ public class MemberService {
     public Member getCurrentMember() throws CustomException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Member member = memberRepository.findByKakaoId(Long.valueOf(authentication.getName()))
-                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+            .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
         return member;
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -7,9 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
 import org.bookwoori.core.domain.server.facade.ServerFacade;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,8 +23,8 @@ public class ServerController {
     private final ServerFacade serverFacade;
 
     @Operation(summary = "모임 서버 생성", description = "모임 서버를 생성합니다.")
-    @PostMapping
-    public ResponseEntity<?> createServer(@RequestBody @Valid ServerCreateRequestDto requestDto) {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> createServer(@Valid @ModelAttribute ServerCreateRequestDto requestDto) {
         serverFacade.createServer(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -9,9 +9,11 @@ import org.bookwoori.core.domain.server.facade.ServerFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,9 +26,16 @@ public class ServerController {
 
     @Operation(summary = "모임 서버 생성", description = "모임 서버를 생성합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> createServer(@Valid @ModelAttribute ServerCreateRequestDto requestDto) {
+    public ResponseEntity<?> createServer(
+        @Valid @ModelAttribute ServerCreateRequestDto requestDto) {
         serverFacade.createServer(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "서버 정보 조회", description = "특정 서버의 정보를 조회합니다.")
+    @GetMapping("/{serverId}")
+    public ResponseEntity<?> getServerDetails(@RequestParam final Long serverId) {
+        return ResponseEntity.ok(serverFacade.getServerDetails(serverId));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -1,7 +1,15 @@
 package org.bookwoori.core.domain.server.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
+import org.bookwoori.core.domain.server.facade.ServerFacade;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/servers")
 public class ServerController {
+
+    private final ServerFacade serverFacade;
+
+    @Operation(summary = "모임 서버 생성", description = "모임 서버를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<?> createServer(@RequestBody @Valid ServerCreateRequestDto requestDto) {
+        serverFacade.createServer(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerCreateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerCreateRequestDto.java
@@ -1,0 +1,24 @@
+package org.bookwoori.core.domain.server.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import org.bookwoori.core.domain.server.entity.Server;
+
+@Getter
+public class ServerCreateRequestDto {
+
+    @NotBlank
+    @Size(max = 20)
+    private String name;
+    private String serverImg;
+    private String description;
+
+    public Server toEntity() {
+        return Server.builder()
+            .name(this.name)
+            .serverImg(this.serverImg)
+            .description(this.description)
+            .build();
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerCreateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerCreateRequestDto.java
@@ -1,23 +1,27 @@
 package org.bookwoori.core.domain.server.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.bookwoori.core.domain.server.entity.Server;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@AllArgsConstructor
 public class ServerCreateRequestDto {
 
-    @NotBlank
+    @NotNull
     @Size(max = 20)
     private String name;
-    private String serverImg;
+    private MultipartFile serverImg;
     private String description;
 
-    public Server toEntity() {
+    public Server toEntity(String url) {
         return Server.builder()
             .name(this.name)
-            .serverImg(this.serverImg)
+            .serverImg(url)
             .description(this.description)
             .build();
     }

--- a/core/src/main/java/org/bookwoori/core/domain/server/dto/response/ServerResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/dto/response/ServerResponseDto.java
@@ -1,0 +1,33 @@
+package org.bookwoori.core.domain.server.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.bookwoori.core.domain.server.entity.Server;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ServerResponseDto {
+
+    private String name;
+    private String serverImg;
+    private String owner;
+    private int memberCount;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+    private String description;
+
+    public static ServerResponseDto from(Server server, String owner, int memberCount) {
+        return ServerResponseDto.builder()
+            .name(server.getName())
+            .serverImg(server.getServerImg())
+            .owner(owner)
+            .memberCount(memberCount)
+            .createdAt(server.getCreatedAt())
+            .description(server.getDescription())
+            .build();
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/server/entity/Server.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/entity/Server.java
@@ -13,9 +13,11 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.bookwoori.core.global.BaseTimeEntity;
 
 @Entity
@@ -23,6 +25,7 @@ import org.bookwoori.core.global.BaseTimeEntity;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Server extends BaseTimeEntity {
 
     @Id
@@ -42,5 +45,8 @@ public class Server extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "server", cascade = CascadeType.ALL)
     private List<Category> categories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "server", cascade = CascadeType.ALL)
+    private List<ServerMember> members = new ArrayList<>();
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -7,6 +7,7 @@ import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
+import org.bookwoori.core.domain.server.dto.response.ServerResponseDto;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
@@ -43,6 +44,14 @@ public class ServerFacade {
         //DEFAULT 카테고리/채널 생성 및 저장
         Category category = categoryService.makeDefaultCategory(server);
         channelService.makeDefaultChannels(category);
-
     }
+
+    public ServerResponseDto getServerDetails(Long serverId) {
+        Server server = serverService.getServerById(serverId);
+        Member owner = serverMemberService.getOwner(server);
+        int memberCount = serverMemberService.getMemberCount(server);
+
+        return ServerResponseDto.from(server, owner.getNickname(), memberCount);
+    }
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -1,0 +1,46 @@
+package org.bookwoori.core.domain.server.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.category.service.CategoryService;
+import org.bookwoori.core.domain.channel.service.ChannelService;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
+import org.bookwoori.core.domain.server.entity.Server;
+import org.bookwoori.core.domain.server.service.ServerService;
+import org.bookwoori.core.domain.serverMember.entity.ServerRole;
+import org.bookwoori.core.domain.serverMember.service.ServerMemberService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ServerFacade {
+
+    private final ServerService serverService;
+    private final MemberService memberService;
+    private final CategoryService categoryService;
+    private final ChannelService channelService;
+    private final ServerMemberService serverMemberService;
+
+    @Transactional
+    public void createServer(ServerCreateRequestDto requestDto) {
+
+        //서버 이미지 저장 - 추가 예정
+
+        //서버 저장
+        Server server = requestDto.toEntity();
+        serverService.saveServer(server);
+
+        //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요
+        Member member = memberService.getMemberById(1L);
+        //서버장을 ServerMember 테이블에 추가
+        serverMemberService.saveServerMember(member, server, ServerRole.OWNER);
+
+        //DEFAULT 카테고리/채널 생성 및 저장
+        Category category = categoryService.makeDefaultCategory(server);
+        channelService.makeDefaultChannels(category);
+
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -11,12 +11,15 @@ import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.service.ServerMemberService;
+import org.bookwoori.core.global.s3.S3Util;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class ServerFacade {
+
+    private final S3Util s3Util;
 
     private final ServerService serverService;
     private final MemberService memberService;
@@ -27,10 +30,9 @@ public class ServerFacade {
     @Transactional
     public void createServer(ServerCreateRequestDto requestDto) {
 
-        //서버 이미지 저장 - 추가 예정
-
         //서버 저장
-        Server server = requestDto.toEntity();
+        Server server = requestDto.toEntity(
+            s3Util.uploadImage(requestDto.getServerImg(), "server"));
         serverService.saveServer(server);
 
         //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -37,7 +37,7 @@ public class ServerFacade {
         serverService.saveServer(server);
 
         //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요
-        Member member = memberService.getMemberById(1L);
+        Member member = memberService.getCurrentMember();
         //서버장을 ServerMember 테이블에 추가
         serverMemberService.saveServerMember(member, server, ServerRole.OWNER);
 

--- a/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
@@ -3,7 +3,10 @@ package org.bookwoori.core.domain.server.service;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.repository.ServerRepository;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,5 +16,12 @@ public class ServerService {
 
     public Server saveServer(Server server) {
         return serverRepository.save(server);
+    }
+
+    @Transactional(readOnly = true)
+    public Server getServerById(Long serverId) {
+        return serverRepository.findById(serverId).orElseThrow(()->{
+            throw new CustomException(ErrorCode.SERVER_NOT_FOUND);
+        });
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
@@ -1,6 +1,7 @@
 package org.bookwoori.core.domain.server.service;
 
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.repository.ServerRepository;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +10,8 @@ import org.springframework.stereotype.Service;
 public class ServerService {
 
     private final ServerRepository serverRepository;
+
+    public Server saveServer(Server server) {
+        return serverRepository.save(server);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
@@ -13,6 +13,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.member.entity.Member;
@@ -22,6 +24,8 @@ import org.bookwoori.core.domain.server.entity.Server;
 @Table(name = "server_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ServerMember {
 
     @Id

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
@@ -1,7 +1,9 @@
-package org.bookwoori.core.domain.member.entity;
+package org.bookwoori.core.domain.serverMember.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,33 +15,33 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.server.entity.Server;
 
 @Entity
-@Table(name = "climbing_member")
+@Table(name = "server_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ClimbingMember {
+public class ServerMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "climbing_member_id", updatable = false)
-    private Long climbingMemberId;
+    @Column(name = "server_member_id", updatable = false)
+    private Long serverMemberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "climbing_id", updatable = false)
-    @NotNull
-    private Climbing climbing;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", updatable = false)
+    @JoinColumn(name = "member_id")
     @NotNull
     private Member member;
 
-    @Column(name = "has_shared")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "server_id")
     @NotNull
-    private boolean hasShared;
+    private Server server;
 
-    @Column(name = "memo")
-    private String memo;
+    @Column(name = "role")
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ServerRole role;
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerRole.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerRole.java
@@ -1,0 +1,6 @@
+package org.bookwoori.core.domain.serverMember.entity;
+
+public enum ServerRole {
+    OWNER,
+    MEMBER;
+}

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
@@ -1,0 +1,8 @@
+package org.bookwoori.core.domain.serverMember.repository;
+
+import org.bookwoori.core.domain.serverMember.entity.ServerMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ServerMemberRepository extends JpaRepository<ServerMember, Long> {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
@@ -1,8 +1,16 @@
 package org.bookwoori.core.domain.serverMember.repository;
 
+import java.util.Optional;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ServerMemberRepository extends JpaRepository<ServerMember, Long> {
 
+    int countByServer(Server server);
+    @Query("SELECT m.member FROM ServerMember m WHERE m.server = :server AND m.role = 'OWNER'")
+    Optional<Member> findOwnerByServer(@Param("server") Server server);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -6,7 +6,10 @@ import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.repository.ServerMemberRepository;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,13 +17,25 @@ public class ServerMemberService {
 
     private final ServerMemberRepository serverMemberRepository;
 
-    public void saveServerMember(Member member, Server server, ServerRole role){
+    public void saveServerMember(Member member, Server server, ServerRole role) {
         ServerMember serverMember = ServerMember.builder()
             .member(member)
             .server(server)
             .role(role)
             .build();
         serverMemberRepository.save(serverMember);
+    }
+
+    @Transactional(readOnly = true)
+    public Member getOwner(Server server) {
+        return serverMemberRepository.findOwnerByServer(server).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.SERVER_OWNER_NOT_FOUND);
+        });
+    }
+
+    @Transactional(readOnly = true)
+    public int getMemberCount(Server server) {
+        return serverMemberRepository.countByServer(server);
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -1,0 +1,12 @@
+package org.bookwoori.core.domain.serverMember.service;
+
+import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.serverMember.repository.ServerMemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ServerMemberService {
+
+    private final ServerMemberRepository serverMemberRepository;
+}

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -1,6 +1,10 @@
 package org.bookwoori.core.domain.serverMember.service;
 
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.server.entity.Server;
+import org.bookwoori.core.domain.serverMember.entity.ServerMember;
+import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.repository.ServerMemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +13,14 @@ import org.springframework.stereotype.Service;
 public class ServerMemberService {
 
     private final ServerMemberRepository serverMemberRepository;
+
+    public void saveServerMember(Member member, Server server, ServerRole role){
+        ServerMember serverMember = ServerMember.builder()
+            .member(member)
+            .server(server)
+            .role(role)
+            .build();
+        serverMemberRepository.save(serverMember);
+    }
+
 }

--- a/core/src/main/java/org/bookwoori/core/global/config/S3Config.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package org.bookwoori.core.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(region)
+            .build();
+    }
+
+}

--- a/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 @EnableMethodSecurity(securedEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -52,9 +53,10 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:3000",
-                "http://localhost:8080"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
+            "http://localhost:3000",
+            "http://localhost:8080"));
+        configuration.setAllowedMethods(
+            Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader("Authorization");
         configuration.setAllowCredentials(true);
@@ -70,35 +72,38 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    public AuthenticationManager authenticationManager(
+        AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
 //                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .logout(AbstractHttpConfigurer::disable)
-                // jwt
-                .addFilterBefore(jwtAuthenticationFilter,
-                        UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new TokenExceptionFilter(), jwtAuthenticationFilter.getClass()) // 토큰 예외 핸들링
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/success","/signup", "/login", "/token").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/playlists/**").permitAll()
-                        .anyRequest().authenticated())
-                // 인증 예외 핸들링
-                .exceptionHandling((exceptions) -> exceptions
-                        .authenticationEntryPoint(customAuthenticationEntryPoint)
-                        .accessDeniedHandler(customAccessDeniedHandler))
-                // oauth2
-                .oauth2Login(oauth -> oauth
-                        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
-                        .successHandler(oAuth2SuccessHandler));
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .sessionManagement(
+                config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .logout(AbstractHttpConfigurer::disable)
+            // jwt
+            .addFilterBefore(jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new TokenExceptionFilter(),
+                jwtAuthenticationFilter.getClass()) // 토큰 예외 핸들링
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/auth/success", "/signup", "/login", "/token").permitAll()
+                .requestMatchers(HttpMethod.GET, "/playlists/**").permitAll()
+                .anyRequest().authenticated())
+            // 인증 예외 핸들링
+            .exceptionHandling((exceptions) -> exceptions
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .accessDeniedHandler(customAccessDeniedHandler))
+            // oauth2
+            .oauth2Login(oauth -> oauth
+                .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
+                .successHandler(oAuth2SuccessHandler));
 //                        .failureHandler(oAuth2FailureHandler))
 //                .logout(logout -> logout
 //                        .logoutUrl("/logout")

--- a/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
@@ -43,9 +43,9 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
-                .requestMatchers("/error", "/favicon.ico",
-                        "/swagger-ui/**", "/swagger-ui.html", "/v3/api/docs", "/v3/api/docs/**")
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+            .requestMatchers("/error", "/favicon.ico",
+                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**")
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
     @Bean

--- a/core/src/main/java/org/bookwoori/core/global/config/SwaggerConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SwaggerConfig.java
@@ -21,22 +21,22 @@ import java.util.Arrays;
 @Configuration
 public class SwaggerConfig {
 
-//    @Bean
-//    public OpenAPI openAPI(){
-//        SecurityScheme bearerAuth = new SecurityScheme()
-//                .type(SecurityScheme.Type.HTTP)
-//                .scheme("bearer")
-//                .bearerFormat("JWT")
-//                .in(SecurityScheme.In.HEADER)
-//                .name(HttpHeaders.AUTHORIZATION);
-//
-//        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
-//
-//        return new OpenAPI()
-//                .components(new Components()
-//                        .addSecuritySchemes("bearerAuth",bearerAuth))
-//                .security(Arrays.asList(securityRequirement));
-//    }
+    @Bean
+    public OpenAPI openAPI(){
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",bearerAuth))
+                .security(Arrays.asList(securityRequirement));
+    }
 
 
     @Bean

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     MISSING_PARAMETER(400, 1001, "필수 파라미터가 누락되었습니다."),
     INVALID_FILE_FORMAT(400, 1500, "잘못된 파일 형식입니다."),
     UNSUPPORTED_FILE_FORMAT(400, 1501, "지원하지 않는 파일 형식입니다."),
-    FILE_UPLOAD_FAIL(500,1502,"파일 업로드에 실패했습니다."),
+    FILE_UPLOAD_FAIL(500, 1502, "파일 업로드에 실패했습니다."),
 
     /*
      * 인증/인가 관련 오류
@@ -28,7 +28,7 @@ public enum ErrorCode {
     ACCESS_DENIED(403, 2001, "접근 권한이 없습니다."),
     INVALID_JWT_SIGNATURE(401, 2003, "잘못된 JWT 서명입니다."),
     INVALID_TOKEN(401, 2100, "잘못된 액세스 토큰입니다."),
-    NO_COOKIE(404,2101 , "쿠키가 존재하지 않습니다."),
+    NO_COOKIE(404, 2101, "쿠키가 존재하지 않습니다."),
     EXPIRED_ACCESS_TOKEN(401, 2200, "만료된 액세스 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(401, 2300, "만료된 리프레쉬 토큰입니다."),
 
@@ -56,7 +56,6 @@ public enum ErrorCode {
 
     // Review (3700 ~ 3799)
     ;
-
 
 
     private final int status;

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -35,9 +35,11 @@ public enum ErrorCode {
      */
 
     // Member (3000 ~ 3099)
-    MEMBER_NOT_FOUND(404, 3000, "사용자를 찾을 수 없습니다.")
+    MEMBER_NOT_FOUND(404, 3000, "사용자를 찾을 수 없습니다."),
+    SERVER_OWNER_NOT_FOUND(404, 3001, "서버 주인을 찾을 수 없습니다."),
 
     // Server (3100 ~ 3199)
+    SERVER_NOT_FOUND(404, 3100, "서버를 찾을 수 없습니다.")
 
     // Category (3200 ~ 3299)
 

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
 
     BAD_REQUEST(400, 1000, "요청의 형식이나 내용이 잘못되었습니다."),
     MISSING_PARAMETER(400, 1001, "필수 파라미터가 누락되었습니다."),
+    INVALID_FILE_FORMAT(400, 1500, "잘못된 파일 형식입니다."),
+    UNSUPPORTED_FILE_FORMAT(400, 1501, "지원하지 않는 파일 형식입니다."),
+    FILE_UPLOAD_FAIL(500,1502,"파일 업로드에 실패했습니다."),
 
     /*
      * 인증/인가 관련 오류

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorDto.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class ErrorDto {
+
     private String timestamp;
     private int status;
     private int code;

--- a/core/src/main/java/org/bookwoori/core/global/exception/TokenException.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/TokenException.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class TokenException extends RuntimeException {
+
     private final ErrorCode errorCode;
 }

--- a/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
@@ -11,7 +11,7 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+        FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenException e) {

--- a/core/src/main/java/org/bookwoori/core/global/jwt/CookieUtil.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/CookieUtil.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 
 @Component
 public class CookieUtil {
+
     public static final int REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60;  // 7일
 
     public void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
@@ -22,14 +23,15 @@ public class CookieUtil {
     public Cookie getCookie(HttpServletRequest request, String name) {
         if (request.getCookies() != null) {
             return Arrays.stream(request.getCookies())
-                    .filter(cookie -> name.equals(cookie.getName()))
-                    .findFirst()
-                    .orElse(null);
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst()
+                .orElse(null);
         }
         return null;
     }
 
-    public void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+    public void deleteCookie(HttpServletRequest request, HttpServletResponse response,
+        String name) {
         Cookie cookie = getCookie(request, name);
         if (cookie != null) {
             cookie.setValue("");

--- a/core/src/main/java/org/bookwoori/core/global/jwt/CustomAccessDeniedHandler.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/CustomAccessDeniedHandler.java
@@ -9,12 +9,14 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+
 @Component
 @RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
         response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access Denied");
     }
 }

--- a/core/src/main/java/org/bookwoori/core/global/jwt/CustomAuthenticationEntryPoint.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/CustomAuthenticationEntryPoint.java
@@ -17,12 +17,14 @@ import java.time.LocalDateTime;
 @Component
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
     private final ObjectMapper objectMapper;
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
         Object exception = request.getAttribute("exception");
-        if(exception instanceof ErrorCode){
+        if (exception instanceof ErrorCode) {
             ErrorCode errorCode = (ErrorCode) exception;
             setResponse(request, response, errorCode);
             return;
@@ -30,16 +32,17 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
 
-    private void setResponse(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode) throws IOException {
+    private void setResponse(HttpServletRequest request, HttpServletResponse response,
+        ErrorCode errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         ErrorDto errorDto = ErrorDto.builder()
-                .timestamp(LocalDateTime.now().toString())
-                .status(errorCode.getStatus())
-                .code(errorCode.getCode())
-                .message(errorCode.getMessage())
-                .path(request.getRequestURI())
-                .build();
+            .timestamp(LocalDateTime.now().toString())
+            .status(errorCode.getStatus())
+            .code(errorCode.getCode())
+            .message(errorCode.getMessage())
+            .path(request.getRequestURI())
+            .build();
         String jsonString = objectMapper.writeValueAsString(errorDto);
         response.getWriter().println(jsonString);
     }

--- a/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
@@ -20,11 +20,12 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @RequiredArgsConstructor
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
     private final TokenProvider tokenProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+        FilterChain filterChain) throws ServletException, IOException {
         String accessToken = resolveToken(request);
 
         // accessToken 검증
@@ -44,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void handleInvalidToken(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws IOException, ServletException {
+        FilterChain filterChain) throws IOException, ServletException {
         // 인증된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null) {

--- a/core/src/main/java/org/bookwoori/core/global/jwt/JwtService.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/JwtService.java
@@ -11,14 +11,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class JwtService {
+
     private final MemberRepository memberRepository;
 
     @Transactional
     public Member getOrCreateMemberByKakaoId(Long kakaoId) {
         return memberRepository.findByKakaoId(kakaoId)
-                .orElse(Member.builder()
-                        .kakaoId(kakaoId)
-                        .build());
+            .orElse(Member.builder()
+                .kakaoId(kakaoId)
+                .build());
     }
 
     // Access Token 저장 또는 업데이트

--- a/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
@@ -29,8 +29,10 @@ import java.util.stream.Collectors;
 @Component
 public class TokenProvider {
 
-    @Value("${jwt.secret.access}") private String accessSecret;
-    @Value("${jwt.secret.refresh}") private String refreshSecret;
+    @Value("${jwt.secret.access}")
+    private String accessSecret;
+    @Value("${jwt.secret.refresh}")
+    private String refreshSecret;
     private SecretKey accessKey;
     private SecretKey refreshKey;
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
@@ -56,7 +58,8 @@ public class TokenProvider {
             return currentToken;
         }
 
-        String newAccessToken = generateToken(kakaoId, authentication.getAuthorities(), ACCESS_TOKEN_EXPIRE_TIME, accessKey, "access");
+        String newAccessToken = generateToken(kakaoId, authentication.getAuthorities(),
+            ACCESS_TOKEN_EXPIRE_TIME, accessKey, "access");
         jwtService.saveOrUpdateAccessToken(member, newAccessToken);
         return newAccessToken;
     }
@@ -65,24 +68,26 @@ public class TokenProvider {
         Long kakaoId = extractKakaoId(authentication);
 
         // refreshToken을 새로 생성하여 저장
-        String refreshToken = generateToken(kakaoId, Collections.emptyList(), REFRESH_TOKEN_EXPIRE_TIME, refreshKey, "refresh");
+        String refreshToken = generateToken(kakaoId, Collections.emptyList(),
+            REFRESH_TOKEN_EXPIRE_TIME, refreshKey, "refresh");
         return refreshToken;
     }
 
-    private String generateToken(Long kakaoId, Collection<? extends GrantedAuthority> authorities, long tokenExpireTime, SecretKey key, String tokenType) {
+    private String generateToken(Long kakaoId, Collection<? extends GrantedAuthority> authorities,
+        long tokenExpireTime, SecretKey key, String tokenType) {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + tokenExpireTime);
 
         String authorityList = authorities.stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining());
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining());
 
         JwtBuilder builder = Jwts.builder()
-                .subject(String.valueOf(kakaoId))  // 토큰에 카카오 ID를 subject로 설정
-                .claim(KEY_TYPE, tokenType)  // 토큰 타입 (access / refresh)
-                .issuedAt(now)
-                .setExpiration(expiredDate)
-                .signWith(key, SignatureAlgorithm.HS512);
+            .subject(String.valueOf(kakaoId))  // 토큰에 카카오 ID를 subject로 설정
+            .claim(KEY_TYPE, tokenType)  // 토큰 타입 (access / refresh)
+            .issuedAt(now)
+            .setExpiration(expiredDate)
+            .signWith(key, SignatureAlgorithm.HS512);
 
         // 만약 권한 정보가 존재한다면, 액세스 토큰에만 추가
         if (!authorityList.isEmpty() && "access".equals(tokenType)) {
@@ -124,9 +129,9 @@ public class TokenProvider {
     private Claims parseClaims(String token) {
         try {
             return Jwts.parser()
-                    .setSigningKey(token.contains("refresh") ? refreshKey : accessKey)
-                    .build()
-                    .parseClaimsJws(token).getBody();
+                .setSigningKey(token.contains("refresh") ? refreshKey : accessKey)
+                .build()
+                .parseClaimsJws(token).getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         } catch (JwtException e) {

--- a/core/src/main/java/org/bookwoori/core/global/s3/S3Util.java
+++ b/core/src/main/java/org/bookwoori/core/global/s3/S3Util.java
@@ -1,0 +1,69 @@
+package org.bookwoori.core.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final AmazonS3 amazonS3;
+    private static final Set<String> ALLOWED_FILE_EXTENSION = Set.of("jpg", "jpeg", "png");
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadImage(MultipartFile multipartFile, String dirName) {
+
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return null;
+        }
+
+        validateFileExtension(multipartFile);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(multipartFile.getContentType());
+        metadata.setContentLength(multipartFile.getSize());
+
+        String fileName = dirName + "/" + UUID.randomUUID().toString() + "_"
+            + multipartFile.getOriginalFilename();
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
+        }
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    private void validateFileExtension(MultipartFile multipartFile) {
+
+        String fileName = multipartFile.getOriginalFilename();
+
+        int lastDotIndex = fileName.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new CustomException(ErrorCode.INVALID_FILE_FORMAT);
+        }
+
+        String extension = fileName.substring(lastDotIndex + 1).toLowerCase();
+
+        if (!ALLOWED_FILE_EXTENSION.contains(extension)) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_FILE_FORMAT);
+        }
+    }
+
+}


### PR DESCRIPTION
## 🛠️ 구현 기능
  - 디렉토리 구조 변경 - ServerMember, ClimbingMember 도메인을 밖으로 분리
  - Category 테이블에 isDefault 필드 추가
  - **모임 서버 생성** API 구현 
  - **서버 정보 조회** API 구현
  - [노션 yml 파일](https://www.notion.so/bookwoori/yml-11461de85852804c8494d05a984bc17b?pvs=4) 업데이트

## 💭 구현 결과

- S3 bucket
![image](https://github.com/user-attachments/assets/c6304fa7-1f1d-447d-8039-0587efe069b1)

## 🎯 Resolve
  - #9  #4 #3
