### PR TITLE
[Fix] 채널 목록 조회 API 오류 수정

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/category/repository/CategoryRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/repository/CategoryRepository.java
@@ -10,6 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findCategoryByServerAndNextNodeIsNull(Server server);
-    @Query("SELECT c FROM Category c JOIN FETCH c.channels WHERE c.server = :server")
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.channels WHERE c.server = :server")
     List<Category> findCategoryByServer(Server server);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
@@ -40,7 +40,7 @@ public class CategoryService {
             .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
-    public List<Category> getCategoriesByServer(Server server) {
+    public List<Category> getCategoriesWithChannels(Server server) {
         return categoryRepository.findCategoryByServer(server);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/entity/ChannelType.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/entity/ChannelType.java
@@ -1,7 +1,20 @@
 package org.bookwoori.core.domain.channel.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
+
 public enum ChannelType {
     CHAT,
     VOICE
     ;
+
+    @JsonCreator
+    public static ChannelType from(String s) {
+        try {
+            return ChannelType.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/entity/ClimbingStatus.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/entity/ClimbingStatus.java
@@ -1,8 +1,22 @@
 package org.bookwoori.core.domain.climbing.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.bookwoori.core.domain.channel.entity.ChannelType;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
+
 public enum ClimbingStatus {
     READY,
     RUNNING,
     FINISHED,
     FAILED;
+
+    @JsonCreator
+    public static ClimbingStatus from(String s) {
+        try {
+            return ClimbingStatus.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/entity/Grade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/entity/Grade.java
@@ -1,7 +1,11 @@
 package org.bookwoori.core.domain.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 
 @Getter
 @AllArgsConstructor
@@ -21,4 +25,13 @@ public enum Grade {
     private final int level;
     private final String mountain;
     private final int height;
+
+    @JsonCreator
+    public static Grade from(String s) {
+        try {
+            return Grade.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/record/entity/ReadingStatus.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/entity/ReadingStatus.java
@@ -1,7 +1,21 @@
 package org.bookwoori.core.domain.record.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.bookwoori.core.domain.member.entity.Grade;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
+
 public enum ReadingStatus {
     WISH,
     READING,
     FINISHED;
+
+    @JsonCreator
+    public static ReadingStatus from(String s) {
+        try {
+            return ReadingStatus.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -69,7 +69,7 @@ public class ServerFacade {
 
     public ServerCategoryListResponseDto getServerCategoryList(Long serverId) {
         Server server = serverService.getServerById(serverId);
-        List<Category> categories = categoryService.getCategoriesByServer(server);
+        List<Category> categories = categoryService.getCategoriesWithChannels(server);
         List<CategoryResponseDto> categoryDtoList = categories.stream()
             .map(category -> {
                 List<ChannelResponseDto> channelDtoList = category.getChannels().stream()

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package org.bookwoori.core.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -15,6 +14,7 @@ public enum ErrorCode {
 
     BAD_REQUEST(400, 1000, "요청의 형식이나 내용이 잘못되었습니다."),
     MISSING_PARAMETER(400, 1001, "필수 파라미터가 누락되었습니다."),
+    INVALID_ENUM_VALUE(400, 1002, "잘못된 ENUM 값입니다."),
     INVALID_FILE_FORMAT(400, 1500, "잘못된 파일 형식입니다."),
     UNSUPPORTED_FILE_FORMAT(400, 1501, "지원하지 않는 파일 형식입니다."),
     FILE_UPLOAD_FAIL(500, 1502, "파일 업로드에 실패했습니다."),


### PR DESCRIPTION
## 🛠️ 구현 기능
  - **채널 목록 조회** API : 채널이 없는 카테고리는 조회되지 않던 문제 해결
  - ENUM 역직렬화 관련 예외처리 코드 추가
  - 메소드명 리팩토링

## 📝 구현 방법
  - JPQL 수정 전 : `@Query("SELECT c FROM Category c JOIN FETCH c.channels WHERE c.server = :server")`
  - JPQL 수정 후 : `@Query("SELECT c FROM Category c LEFT JOIN FETCH c.channels WHERE c.server = :server")`

## 🔥 구현 결과
  - 채널이 있는 카테고리와 없는 카테고리 모두 정상적으로 조회되는 것 확인  
  ![image](https://github.com/user-attachments/assets/004bd7a2-dc48-429e-8cf0-676ae3c02d6d)


## 🎯 Resolve
  - #15 
