### PR TITLE
[Feat] 클라이밍 채널 / 모집 중인 클라이밍 / 내 클라이밍 목록 조회 API 

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookDetailResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookDetailResponseDto.java
@@ -1,7 +1,9 @@
 package org.bookwoori.core.domain.book.dto.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDate;
 import lombok.Builder;
+import org.bookwoori.core.domain.book.entity.Book;
 
 @Builder
 public record BookDetailResponseDto(
@@ -27,6 +29,18 @@ public record BookDetailResponseDto(
             .build();
     }
 
+    public Book toEntity() {
+        return Book.builder()
+            .title(this.title)
+            .author(this.author)
+            .publisher(this.publisher)
+            .pubDate(LocalDate.parse(this.pubDate))
+            .itemPage(this.itemPage != null ? Math.toIntExact(this.itemPage) : null)
+            .isbn13(this.isbn13)
+            .description(this.description)
+            .coverImg(this.cover)
+            .build();
+    }
 }
 
 

--- a/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookInfoDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookInfoDto.java
@@ -1,0 +1,28 @@
+package org.bookwoori.core.domain.book.dto.response;
+
+import java.time.LocalDate;
+import org.bookwoori.core.domain.book.entity.Book;
+
+public record BookInfoDto(
+    String title,
+    String author,
+    String publisher,
+    LocalDate pubDate,
+    int itemPage,
+    String description,
+    String isbn13,
+    String cover) {
+
+    public static BookInfoDto from(Book book) {
+        return new BookInfoDto(
+            book.getTitle(),
+            book.getAuthor(),
+            book.getPublisher(),
+            book.getPubDate(),
+            book.getItemPage(),
+            book.getDescription(),
+            book.getIsbn13(),
+            book.getCoverImg()
+        );
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/book/entity/Book.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/entity/Book.java
@@ -7,7 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "book")
@@ -26,25 +31,27 @@ public class Book {
     @NotNull
     private String title;
 
-    @Column(name = "writer")
+    @Column(name = "author")
     @NotNull
-    private String writer;
+    private String author;
 
     @Column(name = "publisher")
     @NotNull
     private String publisher;
 
-    @Column(name = "page_count")
-    @NotNull
-    private int pageCount;
+    @Column(name = "pub_date")
+    private LocalDate pubDate;
 
-    @Column(name = "isbn", updatable = false, unique = true)
-    @NotNull
-    private String isbn;
+    @Column(name = "item_page")
+    private int itemPage;
 
-    @Column(name = "cover_image", columnDefinition = "TEXT")
-    private String coverImg;
+    @Column(name = "isbn13", updatable = false, unique = true)
+    @NotNull
+    private String isbn13;
 
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
+
+    @Column(name = "cover_image", columnDefinition = "TEXT")
+    private String coverImg;
 }

--- a/core/src/main/java/org/bookwoori/core/domain/book/repository/BookRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/repository/BookRepository.java
@@ -1,10 +1,10 @@
 package org.bookwoori.core.domain.book.repository;
 
+import java.util.Optional;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface BookRepository extends JpaRepository<Book, Long> {
-    Optional<Book> findByIsbn(String isbn);
+
+    Optional<Book> findByIsbn13(String isbn);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
@@ -1,12 +1,22 @@
 package org.bookwoori.core.domain.book.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.book.dto.response.BookDetailResponseDto;
+import org.bookwoori.core.domain.book.dto.response.BookResponseDto;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.repository.BookRepository;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @Transactional
@@ -21,7 +31,7 @@ public class BookService {
     @Autowired
     private final ObjectMapper objectMapper;
     @Value("${aladin.TTB_KEY}")
-    private String TTB_KEY; // 알라딘 API Key
+    private String TTB_KEY;
 
     public List<BookResponseDto> getBooksByKeyword(String keyword) { // 도서 검색
         String url = ALADIN_API_URL_SEARCH + "?ttbkey=" + TTB_KEY +
@@ -61,47 +71,37 @@ public class BookService {
             "&output=js" +
             "&Version=20131101";
 
-        String jsonResponse = restTemplate.getForObject(url, String.class);
-
         try {
+            String jsonResponse = restTemplate.getForObject(url, String.class);
             JsonNode root = objectMapper.readTree(jsonResponse);
             JsonNode item = root.path("item").get(0);
 
             if (item != null) {
                 return BookDetailResponseDto.from(item);
+            } else {
+                throw new CustomException(ErrorCode.BOOK_NOT_FOUND);
             }
         } catch (Exception e) {
             e.printStackTrace();
+            throw new CustomException(ErrorCode.BOOK_NOT_FOUND);
         }
-
-        return null; // 데이터가 없거나 오류 발생 시 null 반환
     }
 
-
-}
-    private final BookRepository bookRepository;
 
     public Book getOrCreateBookByIsbn(String isbn) {
-        return bookRepository.findByIsbn13(isbn)
-            .orElseGet(() -> {
-                Book newBook = Book.builder()
-                    .title("테스트 제목")
-                    .author("테스트 저자")
-                    .publisher("테스트 출판사")
-                    .pubDate(LocalDate.now())
-                    .itemPage(1)
-                    .isbn13(isbn)
-                    .description("기본 설명")
-                    .coverImg("default.jpg")
-                    .build();
-                return bookRepository.save(newBook);
-            });
+        Optional<Book> existingBook = bookRepository.findByIsbn13(isbn);
+        if (existingBook.isPresent()) {
+            return existingBook.get();
+        }
+        Book newBook = getBookByIsbn(isbn).toEntity();
+        return bookRepository.save(newBook);
     }
+
 
     @Transactional(readOnly = true)
     public Book getBookById(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.book.service;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.repository.BookRepository;
@@ -12,28 +13,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class BookService {
+
     private final BookRepository bookRepository;
 
     public Book getOrCreateBookByIsbn(String isbn) {
-        return bookRepository.findByIsbn(isbn)
-                .orElseGet(() -> {
-                    Book newBook = Book.builder()
-                            .isbn(isbn)
-                            .title("테스트 제목")
-                            .writer("테스트 저자 ")
-                            .publisher("테스트 출판사")
-                            .pageCount(0)
-                            .coverImg(null)
-                            .description(null)
-                            .build();
-                    return bookRepository.save(newBook);
-                });
+        return bookRepository.findByIsbn13(isbn)
+            .orElseGet(() -> {
+                Book newBook = Book.builder()
+                    .title("테스트 제목")
+                    .author("테스트 저자")
+                    .publisher("테스트 출판사")
+                    .pubDate(LocalDate.now())
+                    .itemPage(1)
+                    .isbn13(isbn)
+                    .description("기본 설명")
+                    .coverImg("default.jpg")
+                    .build();
+                return bookRepository.save(newBook);
+            });
     }
 
     @Transactional(readOnly = true)
     public Book getBookById(Long bookId) {
         return bookRepository.findById(bookId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -62,4 +62,5 @@ public class ClimbingController {
         return ResponseEntity.ok(climbingFacade.getClimbing(climbingId));
     }
 
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -9,6 +9,7 @@ import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateReque
 import org.bookwoori.core.domain.climbing.facade.ClimbingFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,6 +53,13 @@ public class ClimbingController {
         } else {
             return ResponseEntity.noContent().build();
         }
+    }
+
+    @Operation(summary = "클라이밍 채널 상세정보", description = "클라이밍 채널의 상세정보를 조회합니다.")
+    @GetMapping("/{climbingId}")
+    public ResponseEntity<?> getClimbingChannel(
+        @PathVariable("climbingId") final Long climbingId) {
+        return ResponseEntity.ok(climbingFacade.getClimbing(climbingId));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -45,9 +45,9 @@ public class ClimbingController {
 
     @Operation(summary = "클라이밍 채널 참여 <-> 참여 취소", description = "클라이밍 채널에 참여 <-> 참여를 취소합니다.")
     @PutMapping("/{climbingId}")
-    public ResponseEntity<?> toggleClimbingChannel(
+    public ResponseEntity<?> toggleParticipation(
         @PathVariable("climbingId") final Long climbingId) {
-        boolean isJoined = climbingFacade.toggleClimbing(climbingId);
+        boolean isJoined = climbingFacade.toggleParticipation(climbingId);
         if (isJoined) {
             return ResponseEntity.ok().build();
         } else {
@@ -57,9 +57,9 @@ public class ClimbingController {
 
     @Operation(summary = "클라이밍 채널 상세정보", description = "클라이밍 채널의 상세정보를 조회합니다.")
     @GetMapping("/{climbingId}")
-    public ResponseEntity<?> getClimbingChannel(
+    public ResponseEntity<?> getClimbingDetails(
         @PathVariable("climbingId") final Long climbingId) {
-        return ResponseEntity.ok(climbingFacade.getClimbing(climbingId));
+        return ResponseEntity.ok(climbingFacade.getClimbingDetails(climbingId));
     }
 
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -9,34 +9,49 @@ import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateReque
 import org.bookwoori.core.domain.climbing.facade.ClimbingFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Tag(name = "Climbing")
 @RequiredArgsConstructor
 @RequestMapping("/climbs")
 public class ClimbingController {
+
     private final ClimbingFacade climbingFacade;
 
     @Operation(summary = "클라이밍 채널 생성", description = "클라이밍 채널을 생성합니다.")
     @PostMapping
-    public ResponseEntity<?> createClimbingChannel(@RequestBody @Valid ClimbingChannelCreateRequestDto requestDto) {
+    public ResponseEntity<?> createClimbingChannel(
+        @RequestBody @Valid ClimbingChannelCreateRequestDto requestDto) {
         climbingFacade.createClimbing(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @Operation(summary = "클라이밍 채널 편집", description = "클라이밍 채널을 편집합니다.")
     @PatchMapping("/{climbingId}")
-    public ResponseEntity<?> updateClimbingChannel(@PathVariable("climbingId") final Long climbingId, @RequestBody @Valid ClimbingChannelUpdateRequestDto requestDto) {
+    public ResponseEntity<?> updateClimbingChannel(
+        @PathVariable("climbingId") final Long climbingId,
+        @RequestBody @Valid ClimbingChannelUpdateRequestDto requestDto) {
         climbingFacade.updateClimbing(climbingId, requestDto);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "클라이밍 채널 참여", description = "클라이밍 채널에 참여합니다.")
-    @PatchMapping
-    public ResponseEntity<?> joinClimbingChannel(@PathVariable("climbingId") final Long climbingId) {
-        climbingFacade.joinClimbing(climbingId);
-        return ResponseEntity.ok().build();
+    @Operation(summary = "클라이밍 채널 참여 <-> 참여 취소", description = "클라이밍 채널에 참여 <-> 참여를 취소합니다.")
+    @PutMapping("/{climbingId}")
+    public ResponseEntity<?> toggleClimbingChannel(
+        @PathVariable("climbingId") final Long climbingId) {
+        boolean isJoined = climbingFacade.toggleClimbing(climbingId);
+        if (isJoined) {
+            return ResponseEntity.ok().build();
+        } else {
+            return ResponseEntity.noContent().build();
+        }
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelUpdateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelUpdateRequestDto.java
@@ -3,18 +3,17 @@ package org.bookwoori.core.domain.climbing.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import org.bookwoori.core.domain.climbing.dto.validation.ValidDateRange;
-
 import java.time.LocalDate;
+import org.bookwoori.core.domain.climbing.dto.validation.ValidDateRange;
 
 @ValidDateRange
 public record ClimbingChannelUpdateRequestDto(
-        @NotBlank
-        @Size(max= 40, message = "INVALID_INPUT_LENGTH-채널명은 40자 이내여야 합니다.")
-        String name,
-        @NotNull Long bookId,
-        String description,
-        @NotNull LocalDate startDate,
-        @NotNull LocalDate endDate
-){
+    @NotBlank
+    @Size(max = 40, message = "INVALID_INPUT_LENGTH-채널명은 40자 이내여야 합니다.")
+    String name,
+    String description,
+    @NotNull LocalDate startDate,
+    @NotNull LocalDate endDate
+) {
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
@@ -11,17 +11,24 @@ public record ClimbingDetailsResponseDto(
     String name,
     LocalDate startDate,
     LocalDate endDate,
+    String description,
     int memberCount,
+    boolean isJoined,
+    boolean isOWner,
     BookInfoDto bookInfo) {
 
-    public static ClimbingDetailsResponseDto from(Climbing climbing, int memberCount) {
+    public static ClimbingDetailsResponseDto from(Climbing climbing, int memberCount,
+        boolean isJoined, boolean isOWner) {
         return new ClimbingDetailsResponseDto(
             climbing.getClimbingId(),
             climbing.getStatus(),
             climbing.getName(),
             climbing.getStartDate(),
             climbing.getEndDate(),
+            climbing.getDescription(),
             memberCount,
+            isJoined,
+            isOWner,
             BookInfoDto.from(climbing.getBook())
         );
     }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
@@ -1,0 +1,28 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import java.time.LocalDate;
+import org.bookwoori.core.domain.book.dto.response.BookInfoDto;
+import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
+
+public record ClimbingDetailsResponseDto(
+    Long climbingId,
+    ClimbingStatus status,
+    String name,
+    LocalDate startDate,
+    LocalDate endDate,
+    int memberCount,
+    BookInfoDto bookInfo) {
+
+    public static ClimbingDetailsResponseDto from(Climbing climbing, int memberCount) {
+        return new ClimbingDetailsResponseDto(
+            climbing.getClimbingId(),
+            climbing.getStatus(),
+            climbing.getName(),
+            climbing.getStartDate(),
+            climbing.getEndDate(),
+            memberCount,
+            BookInfoDto.from(climbing.getBook())
+        );
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ServerClimbingListDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ServerClimbingListDto.java
@@ -1,0 +1,14 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import java.util.List;
+
+public record ServerClimbingListDto(
+    List<ClimbingUnitDto> myClimbings,
+    List<ClimbingUnitDto> readyClimbings) {
+
+    public record ClimbingUnitDto(
+        Long climbingId,
+        String cover) {
+
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/entity/Climbing.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/entity/Climbing.java
@@ -61,7 +61,8 @@ public class Climbing extends BaseTimeEntity {
     private LocalDate endDate;
 
     @Builder
-    public Climbing(Long climbingId, Server server, Book book, String name, String description, LocalDate startDate, LocalDate endDate) {
+    public Climbing(Long climbingId, Server server, Book book, String name, String description,
+        LocalDate startDate, LocalDate endDate) {
         this.climbingId = climbingId;
         this.server = server;
         this.book = book;
@@ -72,11 +73,9 @@ public class Climbing extends BaseTimeEntity {
         this.endDate = endDate;
     }
 
-    public void updateClimbing(Book book, String name, String description, LocalDate startDate, LocalDate endDate){
-        this.book = book;
+    public void updateClimbing(String name, String description, LocalDate endDate) {
         this.name = name;
         this.description = description;
-        this.startDate = startDate;
         this.endDate = endDate;
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -42,7 +42,7 @@ public class ClimbingFacade {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
         if (climbing.getStatus() != ClimbingStatus.READY) {
-            throw new CustomException(ErrorCode.CLIMBING_NOT_READY); //
+            throw new CustomException(ErrorCode.CLIMBING_NOT_READY);
         }
         if (!climbingMemberService.isOwner(currentMember, climbing)) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);  // OWNER만 편집 가능
@@ -50,9 +50,17 @@ public class ClimbingFacade {
         climbing.updateClimbing(requestDto.name(), requestDto.description(), requestDto.endDate());
     }
 
-    public void joinClimbing(Long climbingId) {
+    public boolean toggleClimbing(Long climbingId) {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
-        climbingMemberService.saveMember(currentMember, climbing, ClimbingRole.MEMBER);
+        boolean isJoined = climbingMemberService.isJoined(currentMember, climbing);
+        if (isJoined) {
+            climbingMemberService.removeMember(currentMember, climbing);
+            return false;
+        } else {
+            climbingMemberService.saveMember(currentMember, climbing, ClimbingRole.MEMBER);
+            return true;
+        }
     }
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -21,9 +21,11 @@ import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional
 public class ClimbingFacade {
 
     private final MemberService memberService;
@@ -66,6 +68,7 @@ public class ClimbingFacade {
         }
     }
 
+    @Transactional(readOnly = true)
     public ClimbingDetailsResponseDto getClimbingDetails(Long climbingId) {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
@@ -75,6 +78,7 @@ public class ClimbingFacade {
         return ClimbingDetailsResponseDto.from(climbing, memberCount, isJoined, isOwner);
     }
 
+    @Transactional(readOnly = true)
     public ServerClimbingListDto getClimbingList(Long serverId) {
         Member currentMember = memberService.getCurrentMember();
         // myClimbings
@@ -94,18 +98,21 @@ public class ClimbingFacade {
         return new ServerClimbingListDto(myClimbings, readyClimbs);
     }
 
+    @Transactional(readOnly = true)
     public List<ClimbingDetailsResponseDto> getMyClimbingList(Long serverId) {
         Member currentMember = memberService.getCurrentMember();
         List<Climbing> myClimbings = climbingService.getMyClimbings(currentMember, serverId);
         return convertToDto(myClimbings);
     }
 
+    @Transactional(readOnly = true)
     public List<ClimbingDetailsResponseDto> getReadyClimbingList(Long serverId) {
         List<Climbing> readyClimbs = climbingService.getReadyClimbings(serverId);
         return convertToDto(readyClimbs);
     }
 
-    private List<ClimbingDetailsResponseDto> convertToDto(List<Climbing> climbings) {
+    @Transactional(readOnly = true)
+    protected List<ClimbingDetailsResponseDto> convertToDto(List<Climbing> climbings) {
         Member currentMember = memberService.getCurrentMember();
         return climbings.stream()
             .map(climbing -> {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -5,6 +5,7 @@ import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
+import org.bookwoori.core.domain.climbing.dto.response.ClimbingDetailsResponseDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.service.ClimbingService;
@@ -63,4 +64,9 @@ public class ClimbingFacade {
         }
     }
 
+    public ClimbingDetailsResponseDto getClimbing(Long climbingId) {
+        Climbing climbing = climbingService.getClimbingById(climbingId);
+        int memberCount = climbingMemberService.getMemberCount(climbing);
+        return ClimbingDetailsResponseDto.from(climbing, memberCount);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -1,11 +1,14 @@
 package org.bookwoori.core.domain.climbing.facade;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.response.ClimbingDetailsResponseDto;
+import org.bookwoori.core.domain.climbing.dto.response.ServerClimbingListDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.service.ClimbingService;
@@ -65,8 +68,53 @@ public class ClimbingFacade {
     }
 
     public ClimbingDetailsResponseDto getClimbing(Long climbingId) {
+        Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
         int memberCount = climbingMemberService.getMemberCount(climbing);
-        return ClimbingDetailsResponseDto.from(climbing, memberCount);
+        boolean isJoined = climbingMemberService.isJoined(currentMember, climbing);
+        boolean isOwner = climbingMemberService.isOwner(currentMember, climbing);
+        return ClimbingDetailsResponseDto.from(climbing, memberCount, isJoined, isOwner);
+    }
+
+    public ServerClimbingListDto getClimbingList(Long serverId) {
+        Member currentMember = memberService.getCurrentMember();
+        // myClimbings
+        List<ServerClimbingListDto.ClimbingUnitDto> myClimbings = climbingService.getMyClimbings(
+                currentMember, serverId).stream()
+            .limit(3)
+            .map(climbing -> new ServerClimbingListDto.ClimbingUnitDto(climbing.getClimbingId(),
+                climbing.getBook().getCoverImg()))
+            .collect(Collectors.toList());
+        // readyClimbs
+        List<ServerClimbingListDto.ClimbingUnitDto> readyClimbs = climbingService.getReadyClimbings(
+                serverId).stream()
+            .limit(3)
+            .map(climbing -> new ServerClimbingListDto.ClimbingUnitDto(climbing.getClimbingId(),
+                climbing.getBook().getCoverImg()))
+            .collect(Collectors.toList());
+        return new ServerClimbingListDto(myClimbings, readyClimbs);
+    }
+
+    public List<ClimbingDetailsResponseDto> getMyClimbings(Long serverId) {
+        Member currentMember = memberService.getCurrentMember();
+        List<Climbing> myClimbings = climbingService.getMyClimbings(currentMember, serverId);
+        return convertToDto(myClimbings);
+    }
+
+    public List<ClimbingDetailsResponseDto> getReadyClimbings(Long serverId) {
+        List<Climbing> readyClimbs = climbingService.getReadyClimbings(serverId);
+        return convertToDto(readyClimbs);
+    }
+
+    private List<ClimbingDetailsResponseDto> convertToDto(List<Climbing> climbings) {
+        Member currentMember = memberService.getCurrentMember();
+        return climbings.stream()
+            .map(climbing -> {
+                int memberCount = climbingMemberService.getMemberCount(climbing);
+                boolean isJoined = climbingMemberService.isJoined(currentMember, climbing);
+                boolean isOwner = climbingMemberService.isOwner(currentMember, climbing);
+                return ClimbingDetailsResponseDto.from(climbing, memberCount, isJoined, isOwner);
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -1,12 +1,12 @@
 package org.bookwoori.core.domain.climbing.facade;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.service.ClimbingService;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.service.ClimbingMemberService;
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ClimbingFacade {
+
     private final MemberService memberService;
     private final ClimbingService climbingService;
     private final ServerService serverService;
@@ -40,11 +41,13 @@ public class ClimbingFacade {
     public void updateClimbing(Long climbingId, ClimbingChannelUpdateRequestDto requestDto) {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
-        Book book = bookService.getBookById(requestDto.bookId());
+        if (climbing.getStatus() != ClimbingStatus.READY) {
+            throw new CustomException(ErrorCode.CLIMBING_NOT_READY); //
+        }
         if (!climbingMemberService.isOwner(currentMember, climbing)) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);  // OWNER만 편집 가능
         }
-        climbing.updateClimbing(book, requestDto.name(), requestDto.description(), requestDto.startDate(), requestDto.endDate());
+        climbing.updateClimbing(requestDto.name(), requestDto.description(), requestDto.endDate());
     }
 
     public void joinClimbing(Long climbingId) {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -22,7 +22,6 @@ import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
-
 @Component
 @RequiredArgsConstructor
 public class ClimbingFacade {
@@ -54,7 +53,7 @@ public class ClimbingFacade {
         climbing.updateClimbing(requestDto.name(), requestDto.description(), requestDto.endDate());
     }
 
-    public boolean toggleClimbing(Long climbingId) {
+    public boolean toggleParticipation(Long climbingId) {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
         boolean isJoined = climbingMemberService.isJoined(currentMember, climbing);
@@ -67,7 +66,7 @@ public class ClimbingFacade {
         }
     }
 
-    public ClimbingDetailsResponseDto getClimbing(Long climbingId) {
+    public ClimbingDetailsResponseDto getClimbingDetails(Long climbingId) {
         Member currentMember = memberService.getCurrentMember();
         Climbing climbing = climbingService.getClimbingById(climbingId);
         int memberCount = climbingMemberService.getMemberCount(climbing);
@@ -95,13 +94,13 @@ public class ClimbingFacade {
         return new ServerClimbingListDto(myClimbings, readyClimbs);
     }
 
-    public List<ClimbingDetailsResponseDto> getMyClimbings(Long serverId) {
+    public List<ClimbingDetailsResponseDto> getMyClimbingList(Long serverId) {
         Member currentMember = memberService.getCurrentMember();
         List<Climbing> myClimbings = climbingService.getMyClimbings(currentMember, serverId);
         return convertToDto(myClimbings);
     }
 
-    public List<ClimbingDetailsResponseDto> getReadyClimbings(Long serverId) {
+    public List<ClimbingDetailsResponseDto> getReadyClimbingList(Long serverId) {
         List<Climbing> readyClimbs = climbingService.getReadyClimbings(serverId);
         return convertToDto(readyClimbs);
     }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/repository/ClimbingRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/repository/ClimbingRepository.java
@@ -1,8 +1,16 @@
 package org.bookwoori.core.domain.climbing.repository;
 
+import java.util.List;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ClimbingRepository extends JpaRepository<Climbing, Long> {
 
+    @Query("SELECT c FROM Climbing c JOIN ClimbingMember cm ON c = cm.climbing WHERE cm.member = :member AND c.server.serverId = :serverId ORDER BY c.climbingId DESC")
+    List<Climbing> findMyClimbings(Member member, Long serverId);
+
+    @Query("SELECT c FROM Climbing c WHERE c.status = 'READY' AND c.server.serverId = :serverId ORDER BY c.startDate ASC, c.climbingId DESC")
+    List<Climbing> findReadyClimbings(Long serverId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
@@ -1,30 +1,43 @@
 package org.bookwoori.core.domain.climbing.service;
 
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.repository.ClimbingRepository;
+import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ClimbingService {
+
     private final ClimbingRepository climbingRepository;
 
-    public Climbing saveClimbingChannel(Climbing climbing) {return climbingRepository.save(climbing);}
+    public Climbing saveClimbingChannel(Climbing climbing) {
+        return climbingRepository.save(climbing);
+    }
 
     @Transactional(readOnly = true)
-    public Climbing getClimbingById(Long climbingId){
+    public Climbing getClimbingById(Long climbingId) {
         return climbingRepository.findById(climbingId)
-                .orElseThrow(() -> new CustomException(ErrorCode.CLIMBING_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.CLIMBING_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Climbing> getMyClimbings(Member member, Long serverId) {
+        return climbingRepository.findMyClimbings(member, serverId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Climbing> getReadyClimbings(Long serverId) {
+        return climbingRepository.findReadyClimbings(serverId);
     }
 
     @Scheduled(cron = "0 0 0 * * *")
@@ -35,7 +48,8 @@ public class ClimbingService {
         for (Climbing climbing : climbingList) {
             if (climbing.getStartDate().isAfter(today)) {
                 climbing.updateStatus(ClimbingStatus.READY);
-            } else if (climbing.getStartDate().isEqual(today) || climbing.getEndDate().isAfter(today)) {
+            } else if (climbing.getStartDate().isEqual(today) || climbing.getEndDate()
+                .isAfter(today)) {
                 climbing.updateStatus(ClimbingStatus.RUNNING);
             }
 //            } else if (climbing.getEndDate().isBefore(today)) {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
@@ -46,9 +46,7 @@ public class ClimbingService {
         List<Climbing> climbingList = climbingRepository.findAll();
 
         for (Climbing climbing : climbingList) {
-            if (climbing.getStartDate().isAfter(today)) {
-                climbing.updateStatus(ClimbingStatus.READY);
-            } else if (climbing.getStartDate().isEqual(today) || climbing.getEndDate()
+            if (climbing.getStartDate().isAfter(today) && climbing.getEndDate()
                 .isAfter(today)) {
                 climbing.updateStatus(ClimbingStatus.RUNNING);
             }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -1,13 +1,14 @@
 package org.bookwoori.core.domain.climbingMember.repository;
 
-import aj.org.objectweb.asm.commons.Remapper;
+import java.util.Optional;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, Long> {
+
     Optional<ClimbingMember> findByMemberAndClimbing(Member member, Climbing climbing);
+
+    boolean existsByMemberAndClimbing(Member member, Climbing climbing);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -11,4 +11,6 @@ public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, 
     Optional<ClimbingMember> findByMemberAndClimbing(Member member, Climbing climbing);
 
     boolean existsByMemberAndClimbing(Member member, Climbing climbing);
+
+    int countByClimbing(Climbing climbing);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -7,8 +7,10 @@ import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.repository.ClimbingMemberRepository;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ClimbingMemberService {
 
@@ -24,13 +26,20 @@ public class ClimbingMemberService {
             .ifPresent(climbingMemberRepository::delete);
     }
 
+    @Transactional(readOnly = true)
     public boolean isJoined(Member member, Climbing climbing) {
         return climbingMemberRepository.existsByMemberAndClimbing(member, climbing);
     }
 
+    @Transactional(readOnly = true)
     public boolean isOwner(Member member, Climbing climbing) {
         return climbingMemberRepository.findByMemberAndClimbing(member, climbing)
             .map(climbingMember -> climbingMember.getRole() == ClimbingRole.OWNER)
             .orElse(false);
+    }
+
+    @Transactional(readOnly = true)
+    public int getMemberCount(Climbing climbing) {
+        return climbingMemberRepository.countByClimbing(climbing);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -6,8 +6,6 @@ import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.repository.ClimbingMemberRepository;
 import org.bookwoori.core.domain.member.entity.Member;
-import org.bookwoori.core.global.exception.CustomException;
-import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,18 +15,17 @@ public class ClimbingMemberService {
     private final ClimbingMemberRepository climbingMemberRepository;
 
     public void saveMember(Member currentMember, Climbing climbing, ClimbingRole climbingRole) {
-        boolean isJoined = climbingMemberRepository.findByMemberAndClimbing(currentMember, climbing)
-            .isPresent();
-        if (isJoined) {
-            throw new CustomException(ErrorCode.ALREADY_JOINED_CLIMBING);
-        }
-
-        ClimbingMember climbingMember = new ClimbingMember(
-            currentMember,
-            climbing,
-            climbingRole
-        );
+        ClimbingMember climbingMember = new ClimbingMember(currentMember, climbing, climbingRole);
         climbingMemberRepository.save(climbingMember);
+    }
+
+    public void removeMember(Member member, Climbing climbing) {
+        climbingMemberRepository.findByMemberAndClimbing(member, climbing)
+            .ifPresent(climbingMemberRepository::delete);
+    }
+
+    public boolean isJoined(Member member, Climbing climbing) {
+        return climbingMemberRepository.existsByMemberAndClimbing(member, climbing);
     }
 
     public boolean isOwner(Member member, Climbing climbing) {

--- a/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bookwoori.core.domain.member.dto.response.LoginResponseDto;
@@ -12,12 +13,13 @@ import org.bookwoori.core.global.exception.ErrorCode;
 import org.bookwoori.core.global.exception.TokenException;
 import org.bookwoori.core.global.jwt.CookieUtil;
 import org.bookwoori.core.global.jwt.TokenProvider;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -25,6 +27,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
     private final TokenProvider tokenProvider;
     private final AuthFacade authFacade;
     private final CookieUtil cookieUtil;
@@ -37,7 +40,8 @@ public class AuthController {
 
     @Operation(summary = "토큰 재발급", description = "액세스 토큰 및 리프레쉬 토큰을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshAccessToken(@CookieValue(name = "refreshToken") String refreshToken, HttpServletResponse response) {
+    public ResponseEntity<?> refreshAccessToken(
+        @CookieValue(name = "refreshToken") String refreshToken, HttpServletResponse response) {
         try {
             // accessToken과 refreshToken을 모두 재발급
             Map<String, String> tokens = tokenProvider.renewAccessAndRefreshToken(refreshToken);
@@ -45,12 +49,13 @@ public class AuthController {
             String newRefreshToken = tokens.get("refreshToken");
 
             // 새로운 refreshToken을 쿠키에 설정 (CookieUtil 사용)
-            cookieUtil.addCookie(response, "refreshToken", newRefreshToken, CookieUtil.REFRESH_TOKEN_MAX_AGE);
+            cookieUtil.addCookie(response, "refreshToken", newRefreshToken,
+                CookieUtil.REFRESH_TOKEN_MAX_AGE);
 
             // 응답: accessToken은 Authorization 헤더에 설정
             return ResponseEntity.ok()
-                    .header("Authorization", "Bearer " + newAccessToken)
-                    .body("New access and refresh tokens issued");
+                .header("Authorization", "Bearer " + newAccessToken)
+                .body("New access and refresh tokens issued");
         } catch (IllegalArgumentException e) {
             throw new TokenException(ErrorCode.INVALID_TOKEN);
         }
@@ -59,8 +64,9 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "로그아웃 및 리프레쉬 토큰 삭제")
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@CookieValue(name = "refreshToken", required = false) String refreshToken) {
-        if (refreshToken != null) {
+    public ResponseEntity<?> logout(
+        @CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        if (refreshToken == null) {
             throw new TokenException(ErrorCode.INVALID_TOKEN);
         }
         return ResponseEntity.ok().build();

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -63,14 +63,14 @@ public class ServerController {
     @GetMapping("/{serverId}/climbs/me")
     public ResponseEntity<?> getMyClimbingChannelList(
         @PathVariable final Long serverId) {
-        return ResponseEntity.ok(climbingFacade.getMyClimbings(serverId));
+        return ResponseEntity.ok(climbingFacade.getMyClimbingList(serverId));
     }
 
     @Operation(summary = "모집 중인 클라이밍 채널 목록 조회", description = "모집 중인 클라이밍 채널의 목록을 조회합니다.")
     @GetMapping("/{serverId}/climbs/ready")
     public ResponseEntity<?> getReadyClimbingChannelList(
         @PathVariable final Long serverId) {
-        return ResponseEntity.ok(climbingFacade.getReadyClimbings(serverId));
+        return ResponseEntity.ok(climbingFacade.getReadyClimbingList(serverId));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.climbing.facade.ClimbingFacade;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
 import org.bookwoori.core.domain.server.facade.ServerFacade;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ServerController {
 
     private final ServerFacade serverFacade;
+    private final ClimbingFacade climbingFacade;
 
     @Operation(summary = "모임 서버 생성", description = "모임 서버를 생성합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -48,6 +50,27 @@ public class ServerController {
     @GetMapping("/{serverId}/categories")
     public ResponseEntity<?> getCategoryList(@PathVariable final Long serverId) {
         return ResponseEntity.ok(serverFacade.getServerCategoryList(serverId));
+    }
+
+    @Operation(summary = "클라이밍 채널 목록 조회", description = "클라이밍 채널의 목록을 조회합니다.")
+    @GetMapping("/{serverId}/climbs")
+    public ResponseEntity<?> getClimbingChannelList(
+        @PathVariable final Long serverId) {
+        return ResponseEntity.ok(climbingFacade.getClimbingList(serverId));
+    }
+
+    @Operation(summary = "내 클라이밍 채널 목록 조회", description = "내가 참여한 클라이밍 채널의 목록을 조회합니다.")
+    @GetMapping("/{serverId}/climbs/me")
+    public ResponseEntity<?> getMyClimbingChannelList(
+        @PathVariable final Long serverId) {
+        return ResponseEntity.ok(climbingFacade.getMyClimbings(serverId));
+    }
+
+    @Operation(summary = "모집 중인 클라이밍 채널 목록 조회", description = "모집 중인 클라이밍 채널의 목록을 조회합니다.")
+    @GetMapping("/{serverId}/climbs/ready")
+    public ResponseEntity<?> getReadyClimbingChannelList(
+        @PathVariable final Long serverId) {
+        return ResponseEntity.ok(climbingFacade.getReadyClimbings(serverId));
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
@@ -1,16 +1,16 @@
 package org.bookwoori.core.global.config;
 
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.global.exception.TokenExceptionFilter;
 import org.bookwoori.core.global.jwt.CustomAccessDeniedHandler;
 import org.bookwoori.core.global.jwt.CustomAuthenticationEntryPoint;
 import org.bookwoori.core.global.jwt.JwtAuthenticationFilter;
-import org.bookwoori.core.global.oauth.OAuth2UserService;
 import org.bookwoori.core.global.oauth.OAuth2SuccessHandler;
-import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.global.oauth.OAuth2UserService;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -28,8 +28,6 @@ import org.springframework.security.web.authentication.logout.HttpStatusReturnin
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -95,8 +93,7 @@ public class SecurityConfig {
             .addFilterBefore(new TokenExceptionFilter(),
                 jwtAuthenticationFilter.getClass()) // 토큰 예외 핸들링
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/success", "/signup", "/login", "/token").permitAll()
-                .requestMatchers(HttpMethod.GET, "/playlists/**").permitAll()
+                .requestMatchers("/auth/success", "auth/refresh").permitAll()
                 .anyRequest().authenticated())
             // 인증 예외 핸들링
             .exceptionHandling((exceptions) -> exceptions

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -2,7 +2,6 @@ package org.bookwoori.core.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -55,6 +54,7 @@ public enum ErrorCode {
     // Climbing (3400 ~ 3499)
     CLIMBING_NOT_FOUND(404, 3400, "클라이밍 채널을 찾을 수 없습니다."),
     ALREADY_JOINED_CLIMBING(409, 3401, "이미 참여하고 있는 클라이밍 채널입니다."),
+    CLIMBING_NOT_READY(409, 3402, "모집 중인 클라이밍 채널만 편집할 수 있습니다."),
 
     // Book (3500 ~ 3599)
     BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🛠️ 구현 기능
  - 클라이밍 채널 편집 API 프론트 요구사항에 맞게 수정
  - 클라이밍 채널 참여 <-> 참여 취소 API 전환형으로 수정 
  - 클라이밍 채널 정보 조회 API 구현
  - 서버의 클라이밍 채널 목록 조회 API 구현 
  - 내 클라이밍 채널 목록 조회 API 구현
  - 모집 중인 클라이밍 채널 목록조회 API 구현 

## 📝 구현 방법
  - 현재 정렬 기준:
    - 내 클라이밍: `climbingId DESC`
    - 모집 중인 클라이밍: `startDate ASC, climbingId DESC`
    - 다른 좋은 아이디어 있을까요? 
   - 도서 검색 PR (#24) 머지한 이후 BookService의 `getOrCreateBookByIsbn` 수정 예정 
   
## 🎯 Resolve
  - #32 
  - #33 
  - #19 
