### PR TITLE
[Feat] 클라이밍 채널 권한 위임 / 참여자 독서 현황 조회 / 메모 수정 API

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookInfoDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/dto/response/BookInfoDto.java
@@ -1,8 +1,10 @@
 package org.bookwoori.core.domain.book.dto.response;
 
 import java.time.LocalDate;
+import lombok.Builder;
 import org.bookwoori.core.domain.book.entity.Book;
 
+@Builder
 public record BookInfoDto(
     String title,
     String author,
@@ -14,15 +16,15 @@ public record BookInfoDto(
     String cover) {
 
     public static BookInfoDto from(Book book) {
-        return new BookInfoDto(
-            book.getTitle(),
-            book.getAuthor(),
-            book.getPublisher(),
-            book.getPubDate(),
-            book.getItemPage(),
-            book.getDescription(),
-            book.getIsbn13(),
-            book.getCoverImg()
-        );
+        return BookInfoDto.builder()
+            .title(book.getTitle())
+            .author(book.getAuthor())
+            .publisher(book.getPublisher())
+            .pubDate(book.getPubDate())
+            .itemPage(book.getItemPage())
+            .description(book.getDescription())
+            .isbn13(book.getIsbn13())
+            .cover(book.getCoverImg())
+            .build();
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -84,7 +84,7 @@ public class ClimbingController {
 
     @Operation(summary = "클라이밍 채널 참여자 메모 수정", description = "클라이밍 채널 참여자의 메모를 수정합니다.")
     @PatchMapping("/{climbingId}/members/memo")
-    public ResponseEntity<?> getClimbingMemberMemo(
+    public ResponseEntity<?> updateClimbingMemberMemo(
         @PathVariable("climbingId") final Long climbingId,
         @RequestBody @Valid ClimbingMemoUpdateRequestDto requestDto) {
         climbingMemberFacade.updateClimbingMemberMemo(climbingId, requestDto);

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -83,7 +83,7 @@ public class ClimbingController {
     }
 
     @Operation(summary = "클라이밍 채널 참여자 메모 수정", description = "클라이밍 채널 참여자의 메모를 수정합니다.")
-    @GetMapping("/{climbingId}/members/memo")
+    @PatchMapping("/{climbingId}/members/memo")
     public ResponseEntity<?> getClimbingMemberMemo(
         @PathVariable("climbingId") final Long climbingId,
         @RequestBody @Valid ClimbingMemoUpdateRequestDto requestDto) {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/controller/ClimbingController.java
@@ -6,7 +6,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
+import org.bookwoori.core.domain.climbing.dto.request.ClimbingMemoUpdateRequestDto;
+import org.bookwoori.core.domain.climbing.dto.request.ClimbingRoleDelegateRequestDto;
 import org.bookwoori.core.domain.climbing.facade.ClimbingFacade;
+import org.bookwoori.core.domain.climbing.facade.ClimbingMemberFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClimbingController {
 
     private final ClimbingFacade climbingFacade;
+    private final ClimbingMemberFacade climbingMemberFacade;
 
     @Operation(summary = "클라이밍 채널 생성", description = "클라이밍 채널을 생성합니다.")
     @PostMapping
@@ -62,5 +66,28 @@ public class ClimbingController {
         return ResponseEntity.ok(climbingFacade.getClimbingDetails(climbingId));
     }
 
+    @Operation(summary = "클라이밍 채널 권한 위임", description = "클라이밍 채널의 OWNER가 권한을 위임합니다.")
+    @PatchMapping("/{climbingId}/members")
+    public ResponseEntity<?> delegateClimbingRole(
+        @PathVariable("climbingId") final Long climbingId,
+        @RequestBody ClimbingRoleDelegateRequestDto requestDto) {
+        climbingMemberFacade.delegateClimbingRole(climbingId, requestDto);
+        return ResponseEntity.ok().build();
+    }
 
+    @Operation(summary = "클라이밍 채널 참여자 조회", description = "클라이밍 채널 참여자 목록 / 참여자 독서 현황을 조회합니다.")
+    @GetMapping("/{climbingId}/members")
+    public ResponseEntity<?> getClimbingMembers(
+        @PathVariable("climbingId") final Long climbingId) {
+        return ResponseEntity.ok(climbingMemberFacade.getClimbingMembers(climbingId));
+    }
+
+    @Operation(summary = "클라이밍 채널 참여자 메모 수정", description = "클라이밍 채널 참여자의 메모를 수정합니다.")
+    @GetMapping("/{climbingId}/members/memo")
+    public ResponseEntity<?> getClimbingMemberMemo(
+        @PathVariable("climbingId") final Long climbingId,
+        @RequestBody @Valid ClimbingMemoUpdateRequestDto requestDto) {
+        climbingMemberFacade.updateClimbingMemberMemo(climbingId, requestDto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingMemoUpdateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingMemoUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package org.bookwoori.core.domain.climbing.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record ClimbingMemoUpdateRequestDto(
+    @Size(max = 10, message = "INVALID_INPUT_LENGTH-메모는 10자 이내여야 합니다.")
+    String memo) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingRoleDelegateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingRoleDelegateRequestDto.java
@@ -1,0 +1,6 @@
+package org.bookwoori.core.domain.climbing.dto.request;
+
+public record ClimbingRoleDelegateRequestDto(
+    Long memberId) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingDetailsResponseDto.java
@@ -1,10 +1,12 @@
 package org.bookwoori.core.domain.climbing.dto.response;
 
 import java.time.LocalDate;
+import lombok.Builder;
 import org.bookwoori.core.domain.book.dto.response.BookInfoDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 
+@Builder
 public record ClimbingDetailsResponseDto(
     Long climbingId,
     ClimbingStatus status,
@@ -19,17 +21,17 @@ public record ClimbingDetailsResponseDto(
 
     public static ClimbingDetailsResponseDto from(Climbing climbing, int memberCount,
         boolean isJoined, boolean isOWner) {
-        return new ClimbingDetailsResponseDto(
-            climbing.getClimbingId(),
-            climbing.getStatus(),
-            climbing.getName(),
-            climbing.getStartDate(),
-            climbing.getEndDate(),
-            climbing.getDescription(),
-            memberCount,
-            isJoined,
-            isOWner,
-            BookInfoDto.from(climbing.getBook())
-        );
+        return ClimbingDetailsResponseDto.builder()
+            .climbingId(climbing.getClimbingId())
+            .status(climbing.getStatus())
+            .name(climbing.getName())
+            .startDate(climbing.getStartDate())
+            .endDate(climbing.getEndDate())
+            .description(climbing.getDescription())
+            .memberCount(memberCount)
+            .isJoined(isJoined)
+            .isOWner(isOWner)
+            .bookInfo(BookInfoDto.from(climbing.getBook()))
+            .build();
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberResponseDto.java
@@ -1,0 +1,9 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import java.util.List;
+
+public record ClimbingMemberResponseDto(
+    List<ClimbingMemberUnitDto> climbingMemberList
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
@@ -1,0 +1,28 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
+import org.bookwoori.core.domain.record.entity.ReadingStatus;
+
+public record ClimbingMemberUnitDto(
+    Long memberId,
+    String profileImg,
+    int level,
+    String mountain,
+    ReadingStatus status,
+    int currentPage,
+    String memo
+) {
+
+    public static ClimbingMemberUnitDto from(ClimbingMember member, ReadingStatus status,
+        int currentPage) {
+        return new ClimbingMemberUnitDto(
+            member.getMember().getMemberId(),
+            member.getMember().getProfileImg(),
+            member.getMember().getGrade().getLevel(),
+            member.getMember().getGrade().getMountain(),
+            status,
+            currentPage,
+            member.getMemo()
+        );
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
@@ -1,8 +1,10 @@
 package org.bookwoori.core.domain.climbing.dto.response;
 
+import lombok.Builder;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.record.entity.ReadingStatus;
 
+@Builder
 public record ClimbingMemberUnitDto(
     Long memberId,
     String nickname,
@@ -16,15 +18,15 @@ public record ClimbingMemberUnitDto(
 
     public static ClimbingMemberUnitDto from(ClimbingMember member, ReadingStatus status,
         int currentPage) {
-        return new ClimbingMemberUnitDto(
-            member.getMember().getMemberId(),
-            member.getMember().getNickname(),
-            member.getMember().getProfileImg(),
-            member.getMember().getGrade().getLevel(),
-            member.getMember().getGrade().getMountain(),
-            status,
-            currentPage,
-            member.getMemo()
-        );
+        return ClimbingMemberUnitDto.builder()
+            .memberId(member.getMember().getMemberId())
+            .nickname(member.getMember().getNickname())
+            .profileImg(member.getMember().getProfileImg())
+            .level(member.getMember().getGrade().getLevel())
+            .mountain(member.getMember().getGrade().getMountain())
+            .status(status)
+            .currentPage(currentPage)
+            .memo(member.getMemo())
+            .build();
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ClimbingMemberUnitDto.java
@@ -5,6 +5,7 @@ import org.bookwoori.core.domain.record.entity.ReadingStatus;
 
 public record ClimbingMemberUnitDto(
     Long memberId,
+    String nickname,
     String profileImg,
     int level,
     String mountain,
@@ -17,6 +18,7 @@ public record ClimbingMemberUnitDto(
         int currentPage) {
         return new ClimbingMemberUnitDto(
             member.getMember().getMemberId(),
+            member.getMember().getNickname(),
             member.getMember().getProfileImg(),
             member.getMember().getGrade().getLevel(),
             member.getMember().getGrade().getMountain(),

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/MyClimbingListResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/MyClimbingListResponseDto.java
@@ -1,0 +1,9 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import java.util.List;
+
+public record MyClimbingListResponseDto(
+    List<ClimbingDetailsResponseDto> myClimbingList
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ReadyClimbingListResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/response/ReadyClimbingListResponseDto.java
@@ -1,0 +1,9 @@
+package org.bookwoori.core.domain.climbing.dto.response;
+
+import java.util.List;
+
+public record ReadyClimbingListResponseDto(
+    List<ClimbingDetailsResponseDto> readyClimbingList
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.climbing.facade;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -12,15 +13,18 @@ import org.bookwoori.core.domain.climbing.dto.response.ServerClimbingListDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.service.ClimbingService;
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.service.ClimbingMemberService;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.domain.record.entity.ReadingStatus;
 import org.bookwoori.core.domain.record.service.RecordService;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +39,32 @@ public class ClimbingFacade {
     private final BookService bookService;
     private final ClimbingMemberService climbingMemberService;
     private final RecordService recordService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateClimbingStatus() {
+        LocalDate today = LocalDate.now();
+        List<Climbing> climbingList = climbingService.getAllClimbings();
+        for (Climbing climbing : climbingList) {
+            if (climbing.getStartDate().isAfter(today) && climbing.getEndDate()
+                .isAfter(today)) {
+                climbing.updateStatus(ClimbingStatus.RUNNING);
+            } else if (climbing.getEndDate().isBefore(today)) {
+                List<ClimbingMember> climbingMemberList = climbingMemberService.findMembersByClimbing(
+                    climbing);
+                boolean allFinished = climbingMemberList.stream()
+                    .allMatch(
+                        member -> recordService.getClimbingMemberRecord(member, climbing.getBook())
+                            .map(record -> record.getStatus() == ReadingStatus.FINISHED)
+                            .orElse(false));
+                if (allFinished) {
+                    climbing.updateStatus(ClimbingStatus.FINISHED);
+                } else {
+                    climbing.updateStatus(ClimbingStatus.FAILED);
+                }
+            }
+            climbingService.saveClimbingChannel(climbing);
+        }
+    }
 
     public void createClimbing(ClimbingChannelCreateRequestDto requestDto) {
         Member currentMember = memberService.getCurrentMember();

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -60,6 +60,9 @@ public class ClimbingFacade {
         Climbing climbing = climbingService.getClimbingById(climbingId);
         boolean isJoined = climbingMemberService.isJoined(currentMember, climbing);
         if (isJoined) {
+            if (climbingMemberService.isOwner(currentMember, climbing)) {
+                throw new CustomException(ErrorCode.OWNER_CANNOT_LEAVE);
+            }
             climbingMemberService.removeMember(currentMember, climbing);
             return false;
         } else {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -16,6 +16,7 @@ import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.service.ClimbingMemberService;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.domain.record.service.RecordService;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.global.exception.CustomException;
@@ -33,6 +34,7 @@ public class ClimbingFacade {
     private final ServerService serverService;
     private final BookService bookService;
     private final ClimbingMemberService climbingMemberService;
+    private final RecordService recordService;
 
     public void createClimbing(ClimbingChannelCreateRequestDto requestDto) {
         Member currentMember = memberService.getCurrentMember();

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -9,6 +9,8 @@ import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.response.ClimbingDetailsResponseDto;
+import org.bookwoori.core.domain.climbing.dto.response.MyClimbingListResponseDto;
+import org.bookwoori.core.domain.climbing.dto.response.ReadyClimbingListResponseDto;
 import org.bookwoori.core.domain.climbing.dto.response.ServerClimbingListDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
@@ -134,16 +136,18 @@ public class ClimbingFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<ClimbingDetailsResponseDto> getMyClimbingList(Long serverId) {
+    public MyClimbingListResponseDto getMyClimbingList(Long serverId) {
         Member currentMember = memberService.getCurrentMember();
         List<Climbing> myClimbings = climbingService.getMyClimbings(currentMember, serverId);
-        return convertToDto(myClimbings);
+        List<ClimbingDetailsResponseDto> myClimbingList = convertToDto(myClimbings);
+        return new MyClimbingListResponseDto(myClimbingList);
     }
 
     @Transactional(readOnly = true)
-    public List<ClimbingDetailsResponseDto> getReadyClimbingList(Long serverId) {
-        List<Climbing> readyClimbs = climbingService.getReadyClimbings(serverId);
-        return convertToDto(readyClimbs);
+    public ReadyClimbingListResponseDto getReadyClimbingList(Long serverId) {
+        List<Climbing> readyClimbings = climbingService.getReadyClimbings(serverId);
+        List<ClimbingDetailsResponseDto> readyClimbingList = convertToDto(readyClimbings);
+        return new ReadyClimbingListResponseDto(readyClimbingList);
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
@@ -48,7 +48,7 @@ public class ClimbingMemberFacade {
 
     public void updateClimbingMemberMemo(Long climbingId, ClimbingMemoUpdateRequestDto requestDto) {
         Member currentMember = memberService.getCurrentMember();
-        ClimbingMember climbingMember = climbingMemberService.findByMemberAndClimbing(currentMember,
+        ClimbingMember climbingMember = climbingMemberService.findByClimbing(currentMember,
             climbingId);
         climbingMember.updateMemo(requestDto.memo());
     }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
@@ -1,0 +1,61 @@
+package org.bookwoori.core.domain.climbing.facade;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.climbing.dto.request.ClimbingMemoUpdateRequestDto;
+import org.bookwoori.core.domain.climbing.dto.request.ClimbingRoleDelegateRequestDto;
+import org.bookwoori.core.domain.climbing.dto.response.ClimbingMemberUnitDto;
+import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.service.ClimbingService;
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
+import org.bookwoori.core.domain.climbingMember.service.ClimbingMemberService;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.domain.record.entity.ReadingStatus;
+import org.bookwoori.core.domain.record.entity.Record;
+import org.bookwoori.core.domain.record.service.RecordService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ClimbingMemberFacade {
+
+    private final MemberService memberService;
+    private final ClimbingService climbingService;
+    private final ClimbingMemberService climbingMemberService;
+    private final RecordService recordService;
+
+    @Transactional(readOnly = true)
+    public List<ClimbingMemberUnitDto> getClimbingMembers(Long climbingId) {
+        Climbing climbing = climbingService.getClimbingById(climbingId);
+        List<ClimbingMember> climbingMemberList = climbingMemberService.findMembersByClimbing(
+            climbing);
+        return climbingMemberList.stream()
+            .map(member -> {
+                Optional<Record> record = recordService.getClimbingMemerRecord(member,
+                    climbing.getBook());
+                ReadingStatus status = record.map(Record::getStatus).orElse(ReadingStatus.UNREAD);
+                int currentPage = record.map(Record::getCurrentPage).orElse(0);
+                return ClimbingMemberUnitDto.from(member, status, currentPage);
+            })
+            .collect(Collectors.toList());
+    }
+
+
+    public void updateClimbingMemberMemo(Long climbingId, ClimbingMemoUpdateRequestDto requestDto) {
+        Member currentMember = memberService.getCurrentMember();
+        ClimbingMember climbingMember = climbingMemberService.findByMemberAndClimbing(currentMember,
+            climbingId);
+        climbingMember.updateMemo(requestDto.memo());
+    }
+
+    public void delegateClimbingRole(Long climbingId, ClimbingRoleDelegateRequestDto requestDto) {
+        Member currentMember = memberService.getCurrentMember();
+        Member newOwner = memberService.getMemberById(requestDto.memberId());
+        climbingMemberService.delegateClimbingRole(climbingId, currentMember, newOwner);
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
@@ -47,6 +47,7 @@ public class ClimbingMemberFacade {
 
 
     public void updateClimbingMemberMemo(Long climbingId, ClimbingMemoUpdateRequestDto requestDto) {
+        climbingService.isRunning(climbingId);
         Member currentMember = memberService.getCurrentMember();
         ClimbingMember climbingMember = climbingMemberService.findByClimbing(currentMember,
             climbingId);

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
@@ -36,7 +36,7 @@ public class ClimbingMemberFacade {
             climbing);
         return climbingMemberList.stream()
             .map(member -> {
-                Optional<Record> record = recordService.getClimbingMemerRecord(member,
+                Optional<Record> record = recordService.getClimbingMemberRecord(member,
                     climbing.getBook());
                 ReadingStatus status = record.map(Record::getStatus).orElse(ReadingStatus.UNREAD);
                 int currentPage = record.map(Record::getCurrentPage).orElse(0);

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
@@ -3,6 +3,7 @@ package org.bookwoori.core.domain.climbing.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.repository.ClimbingRepository;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.global.exception.CustomException;
@@ -40,6 +41,14 @@ public class ClimbingService {
     @Transactional(readOnly = true)
     public List<Climbing> getAllClimbings() {
         return climbingRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public void isRunning(Long climbingId) {
+        Climbing climbing = getClimbingById(climbingId);
+        if (climbing.getStatus() != ClimbingStatus.RUNNING) {
+            throw new CustomException(ErrorCode.CLIMBING_NOT_RUNNING);
+        }
     }
 }
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/service/ClimbingService.java
@@ -1,15 +1,12 @@
 package org.bookwoori.core.domain.climbing.service;
 
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
-import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.repository.ClimbingRepository;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,21 +37,9 @@ public class ClimbingService {
         return climbingRepository.findReadyClimbings(serverId);
     }
 
-    @Scheduled(cron = "0 0 0 * * *")
-    public void updateClimbingStatus() {
-        LocalDate today = LocalDate.now();
-        List<Climbing> climbingList = climbingRepository.findAll();
-
-        for (Climbing climbing : climbingList) {
-            if (climbing.getStartDate().isAfter(today) && climbing.getEndDate()
-                .isAfter(today)) {
-                climbing.updateStatus(ClimbingStatus.RUNNING);
-            }
-//            } else if (climbing.getEndDate().isBefore(today)) {
-//                climbing.updateStatus(ClimbingStatus.COMPLETED);
-//            }
-            climbingRepository.save(climbing);
-        }
+    @Transactional(readOnly = true)
+    public List<Climbing> getAllClimbings() {
+        return climbingRepository.findAll();
     }
 }
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
@@ -62,4 +62,12 @@ public class ClimbingMember {
         this.hasShared = false;
         this.memo = null;
     }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public void updateRole(ClimbingRole climbingRole) {
+        this.role = climbingRole;
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.climbingMember.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
@@ -13,4 +14,8 @@ public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, 
     boolean existsByMemberAndClimbing(Member member, Climbing climbing);
 
     int countByClimbing(Climbing climbing);
+
+    List<ClimbingMember> findByClimbing(Climbing climbing);
+
+    Optional<ClimbingMember> findByMemberAndClimbing_Id(Member member, Long climbingId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -17,5 +17,5 @@ public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, 
 
     List<ClimbingMember> findByClimbing(Climbing climbing);
 
-    Optional<ClimbingMember> findByMemberAndClimbing_Id(Member member, Long climbingId);
+    Optional<ClimbingMember> findByMemberAndClimbing_ClimbingId(Member member, Long climbingId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/repository/ClimbingMemberRepository.java
@@ -6,6 +6,8 @@ import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, Long> {
 
@@ -15,7 +17,8 @@ public interface ClimbingMemberRepository extends JpaRepository<ClimbingMember, 
 
     int countByClimbing(Climbing climbing);
 
-    List<ClimbingMember> findByClimbing(Climbing climbing);
+    @Query("SELECT cm FROM ClimbingMember cm JOIN FETCH cm.member WHERE cm.climbing = :climbing")
+    List<ClimbingMember> findByClimbingWithMember(@Param("climbing") Climbing climbing);
 
     Optional<ClimbingMember> findByMemberAndClimbing_ClimbingId(Member member, Long climbingId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -48,7 +48,7 @@ public class ClimbingMemberService {
 
     @Transactional(readOnly = true)
     public List<ClimbingMember> findMembersByClimbing(Climbing climbing) {
-        return climbingMemberRepository.findByClimbing(climbing);
+        return climbingMemberRepository.findByClimbingWithMember(climbing);
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -53,7 +53,7 @@ public class ClimbingMemberService {
 
     @Transactional(readOnly = true)
     public ClimbingMember findByMemberAndClimbing(Member member, Long climbingId) {
-        return climbingMemberRepository.findByMemberAndClimbing_Id(member, climbingId)
+        return climbingMemberRepository.findByMemberAndClimbing_ClimbingId(member, climbingId)
             .orElseThrow(() -> new CustomException(ErrorCode.CLIMBINGMEMBER_NOT_FOUND));
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -1,11 +1,14 @@
 package org.bookwoori.core.domain.climbingMember.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
 import org.bookwoori.core.domain.climbingMember.repository.ClimbingMemberRepository;
 import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,5 +44,27 @@ public class ClimbingMemberService {
     @Transactional(readOnly = true)
     public int getMemberCount(Climbing climbing) {
         return climbingMemberRepository.countByClimbing(climbing);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ClimbingMember> findMembersByClimbing(Climbing climbing) {
+        return climbingMemberRepository.findByClimbing(climbing);
+    }
+
+    @Transactional(readOnly = true)
+    public ClimbingMember findByMemberAndClimbing(Member member, Long climbingId) {
+        return climbingMemberRepository.findByMemberAndClimbing_Id(member, climbingId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CLIMBINGMEMBER_NOT_FOUND));
+    }
+
+    public void delegateClimbingRole(Long climbingId, Member currentMember,
+        Member newOwner) {
+        ClimbingMember currentClimbingMember = findByMemberAndClimbing(currentMember, climbingId);
+        ClimbingMember newClimbingOwner = findByMemberAndClimbing(newOwner, climbingId);
+        if (currentClimbingMember.getRole() != ClimbingRole.OWNER) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        currentClimbingMember.updateRole(ClimbingRole.MEMBER);
+        newClimbingOwner.updateRole(ClimbingRole.OWNER);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -52,15 +52,15 @@ public class ClimbingMemberService {
     }
 
     @Transactional(readOnly = true)
-    public ClimbingMember findByMemberAndClimbing(Member member, Long climbingId) {
+    public ClimbingMember findByClimbing(Member member, Long climbingId) {
         return climbingMemberRepository.findByMemberAndClimbing_ClimbingId(member, climbingId)
             .orElseThrow(() -> new CustomException(ErrorCode.CLIMBINGMEMBER_NOT_FOUND));
     }
 
     public void delegateClimbingRole(Long climbingId, Member currentMember,
         Member newOwner) {
-        ClimbingMember currentClimbingMember = findByMemberAndClimbing(currentMember, climbingId);
-        ClimbingMember newClimbingOwner = findByMemberAndClimbing(newOwner, climbingId);
+        ClimbingMember currentClimbingMember = findByClimbing(currentMember, climbingId);
+        ClimbingMember newClimbingOwner = findByClimbing(newOwner, climbingId);
         if (currentClimbingMember.getRole() != ClimbingRole.OWNER) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }

--- a/core/src/main/java/org/bookwoori/core/domain/member/entity/Member.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/entity/Member.java
@@ -1,14 +1,19 @@
 package org.bookwoori.core.domain.member.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.global.BaseTimeEntity;
-import org.bookwoori.core.global.s3.S3Util;
-import org.springframework.web.multipart.MultipartFile;
 
 @Entity
 @Table(name = "member")
@@ -66,5 +71,4 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.profileImg = profileImgUrl;
     }
-
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
@@ -32,11 +32,10 @@ public class MemberService {
         return member;
     }
 
-    @Transactional(readOnly = true)
-    public void getMemberStatus(Long kakaoId){
+    public void getMemberStatus(Long kakaoId) {
         memberRepository.findByKakaoId(kakaoId)
-                .filter(member -> member.getStatus() != Status.INACTIVE)
-                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_INACTIVE));
+            .filter(member -> member.getStatus() != Status.INACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_INACTIVE));
     }
 
     public void saveMember(Member member) {

--- a/core/src/main/java/org/bookwoori/core/domain/record/entity/ReadingStatus.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/entity/ReadingStatus.java
@@ -1,11 +1,11 @@
 package org.bookwoori.core.domain.record.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.bookwoori.core.domain.member.entity.Grade;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 
 public enum ReadingStatus {
+    UNREAD,
     WISH,
     READING,
     FINISHED;

--- a/core/src/main/java/org/bookwoori/core/domain/record/repository/RecordRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/repository/RecordRepository.java
@@ -1,8 +1,12 @@
 package org.bookwoori.core.domain.record.repository;
 
+import java.util.Optional;
+import org.bookwoori.core.domain.book.entity.Book;
+import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.record.entity.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
 
+    Optional<Record> findByMemberAndBook(Member climbingMember, Book book);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/record/service/RecordService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/service/RecordService.java
@@ -1,12 +1,22 @@
 package org.bookwoori.core.domain.record.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.book.entity.Book;
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
+import org.bookwoori.core.domain.record.entity.Record;
 import org.bookwoori.core.domain.record.repository.RecordRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class RecordService {
 
     private final RecordRepository recordRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<Record> getClimbingMemerRecord(ClimbingMember climbingMember, Book book) {
+        return recordRepository.findByMemberAndBook(climbingMember.getMember(), book);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/record/service/RecordService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/service/RecordService.java
@@ -16,7 +16,7 @@ public class RecordService {
     private final RecordRepository recordRepository;
 
     @Transactional(readOnly = true)
-    public Optional<Record> getClimbingMemerRecord(ClimbingMember climbingMember, Book book) {
+    public Optional<Record> getClimbingMemberRecord(ClimbingMember climbingMember, Book book) {
         return recordRepository.findByMemberAndBook(climbingMember.getMember(), book);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -71,6 +71,7 @@ public class ServerController {
     public ResponseEntity<?> getReadyClimbingChannelList(
         @PathVariable final Long serverId) {
         return ResponseEntity.ok(climbingFacade.getReadyClimbingList(serverId));
+    }
 
     @Operation(summary = "초대코드 조회 또는 생성", description = "특정 서버에 대한 초대 코드를 조회 또는 생성합니다.")
     @PostMapping("/{serverId}/code")

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     ALREADY_JOINED_CLIMBING(409, 3401, "이미 참여하고 있는 클라이밍 채널입니다."),
     CLIMBING_NOT_READY(409, 3402, "모집 중인 클라이밍 채널만 편집할 수 있습니다."),
     OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
+    CLIMBINGMEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
 
     // Book (3500 ~ 3599)
     BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다.")

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -55,13 +55,15 @@ public enum ErrorCode {
     CLIMBING_NOT_FOUND(404, 3400, "클라이밍 채널을 찾을 수 없습니다."),
     ALREADY_JOINED_CLIMBING(409, 3401, "이미 참여하고 있는 클라이밍 채널입니다."),
     CLIMBING_NOT_READY(409, 3402, "모집 중인 클라이밍 채널만 편집할 수 있습니다."),
+    OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
 
     // Book (3500 ~ 3599)
-    BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),
+    BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다.")
 
     // Record (3600 ~ 3699)
 
     ;
+
 
     private final int status;
     private final int code;

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -58,9 +58,10 @@ public enum ErrorCode {
     CLIMBING_NOT_READY(409, 3402, "모집 중인 클라이밍 채널만 편집할 수 있습니다."),
     OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
     CLIMBINGMEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
+    CLIMBING_NOT_RUNNING(409, 3405, "진행 중인 클라이밍이 아닙니다."),
 
     // Book (3500 ~ 3599)
-    BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다.")
+    BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),
 
     // Record (3600 ~ 3699)
 


### PR DESCRIPTION
## 🛠️ 구현 기능
 - 참여자 메모 수정 API
 - 참여자 독서 현황 조회 API
 - 클라이밍 채널 권한 위임 API
 - 클라이밍 채널 참여 취소 시 Role이 OWNER인 경우 에러 처리 
 - 클라이밍 채널 상태 업데이트 메서드 수정 

## 📝 구현 방법
  - 참여자 독서 현황 조회 시 읽지 않은 멤버의 ReadingStatus를 처리하기 위해 UNREAD 추가 
  - ClimbingMember에 memo 필드가 존재하므로 수정 API만 구현 (메모가 없는 경우 / 삭제 시에는 null) 

## 🎯 Resolve
  - #41 
  - #52 