### PR TITLE
[Feat] 카테고리 삭제 API

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/category/controller/CategoryController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/controller/CategoryController.java
@@ -9,6 +9,7 @@ import org.bookwoori.core.domain.category.dto.request.CategoryUpdateRequestDto;
 import org.bookwoori.core.domain.category.facade.CategoryFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +31,13 @@ public class CategoryController {
         @Valid @RequestBody CategoryCreateRequestDto requestDto) {
         categoryFacade.createCategory(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "카테고리 삭제", description = "카테고리를 삭제합니다.")
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<?> deleteCategory(@PathVariable final Long categoryId) {
+        categoryFacade.deleteCategory(categoryId);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "카테고리 이름 변경", description = "카테고리 이름을 변경합니다.")

--- a/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
@@ -63,8 +63,28 @@ public class Category {
     public void setBeforeNode(Category category) {
         this.beforeNode = category;
         if (!Objects.isNull(category)) {
-            category.nextNode = this;
+            category.setNextNode(this);
         }
+    }
+
+    public void setNextNode(Category category) {
+        this.nextNode = category;
+    }
+
+    public void connectBeforeAndAfterNodes() {
+        Category beforeCategory = this.beforeNode;
+        Category nextCategory = this.nextNode;
+
+        if (nextCategory != null) {
+            nextCategory.setBeforeNode(beforeCategory);
+        } else {
+            if (beforeCategory != null) {
+                beforeCategory.setNextNode(null);
+            }
+        }
+
+        this.beforeNode = null;
+        this.nextNode = null;
     }
 
     public void modifyName(String name) {

--- a/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
@@ -1,19 +1,25 @@
 package org.bookwoori.core.domain.category.facade;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.category.dto.request.CategoryCreateRequestDto;
 import org.bookwoori.core.domain.category.dto.request.CategoryUpdateRequestDto;
 import org.bookwoori.core.domain.category.entity.Category;
 import org.bookwoori.core.domain.category.service.CategoryService;
+import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Log4j2
 public class CategoryFacade {
 
+    private final ChannelService channelService;
     private final CategoryService categoryService;
     private final ServerService serverService;
 
@@ -30,5 +36,22 @@ public class CategoryFacade {
     public void updateCategoryName(Long categoryId, CategoryUpdateRequestDto requestDto) {
         Category category = categoryService.getCategoryById(categoryId);
         category.modifyName(requestDto.name());
+    }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        Category categoryToDelete = categoryService.getCategoryWithChannels(categoryId);
+
+        //기본 카테고리를 삭제하려는 경우 예외처리
+        if (categoryToDelete.isDefault()) {
+            throw new CustomException(ErrorCode.DEFAULT_CATEGORY_EXCEPTION);
+        }
+        Category defaultCategory = categoryService.getDefaultCategoryByServer(
+            categoryToDelete.getServer());
+        //하위 채널들을 기본 카테고리로 이동
+        channelService.moveChannelsToCategory(categoryToDelete, defaultCategory);
+        //카테고리 순서 재설정
+        categoryService.detach(categoryToDelete);
+        categoryService.delete(categoryToDelete);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/repository/CategoryRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/repository/CategoryRepository.java
@@ -10,6 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findCategoryByServerAndNextNodeIsNull(Server server);
+
     @Query("SELECT c FROM Category c LEFT JOIN FETCH c.channels WHERE c.server = :server")
-    List<Category> findCategoryByServer(Server server);
+    List<Category> findCategoriesByServer(Server server);
+
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.channels WHERE c.categoryId = :categoryId")
+    Optional<Category> findCategoryWithChannelsById(Long categoryId);
+
+    @Query("SELECT c FROM Category c WHERE c.server = :server AND c.isDefault = true")
+    Optional<Category> findDefaultCategoryByServer(Server server);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
@@ -29,6 +29,12 @@ public class CategoryService {
         return categoryRepository.save(category);
     }
 
+    @Transactional
+    public Category getDefaultCategoryByServer(Server server) {
+        return categoryRepository.findDefaultCategoryByServer(server)
+            .orElseGet(() -> makeDefaultCategory(server));
+    }
+
     @Transactional(readOnly = true)
     public Category getLastNodeByServer(Server server) {
         return categoryRepository.findCategoryByServerAndNextNodeIsNull(server).orElse(null);
@@ -41,6 +47,21 @@ public class CategoryService {
     }
 
     public List<Category> getCategoriesWithChannels(Server server) {
-        return categoryRepository.findCategoryByServer(server);
+        return categoryRepository.findCategoriesByServer(server);
+    }
+
+    @Transactional(readOnly = true)
+    public Category getCategoryWithChannels(Long categoryId) {
+        return categoryRepository.findCategoryWithChannelsById(categoryId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+
+    public void detach(Category category) {
+        category.connectBeforeAndAfterNodes();
+        categoryRepository.flush();
+    }
+
+    public void delete(Category category) {
+        categoryRepository.delete(category);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/entity/Channel.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/entity/Channel.java
@@ -68,4 +68,11 @@ public class Channel extends BaseTimeEntity {
         this.name = name;
     }
 
+    public void modifyCategory(Category category) {
+        if (category != null) {
+            category.getChannels().remove(this);
+        }
+        this.category = category;
+    }
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/repository/ChannelRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/repository/ChannelRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ChannelRepository extends JpaRepository<Channel, Long> {
 
     Optional<Channel> findChannelByCategoryAndNextNodeIsNull(Category category);
+
+    Optional<Channel> findChannelByCategoryAndBeforeNodeIsNull(Category category);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
@@ -42,8 +42,22 @@ public class ChannelService {
     }
 
     @Transactional(readOnly = true)
+    public Channel getFirstNodeByCategory(Category category) {
+        return channelRepository.findChannelByCategoryAndBeforeNodeIsNull(category).orElse(null);
+    }
+
+    @Transactional(readOnly = true)
     public Channel getChannelById(Long channelId) {
         return channelRepository.findById(channelId)
             .orElseThrow(() -> new CustomException(ErrorCode.CHANNEL_NOT_FOUND));
+    }
+
+    @Transactional
+    public void moveChannelsToCategory(Category from, Category to) {
+        Channel nextChannel = getFirstNodeByCategory(from);
+        if (nextChannel != null) {
+            nextChannel.setBeforeNode(getLastNodeByCategory(to));
+        }
+        from.getChannels().forEach(channel -> channel.modifyCategory(to));
     }
 }

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 
     // Category (3200 ~ 3299)
     CATEGORY_NOT_FOUND(404, 3200, "카테고리를 찾을 수 없습니다."),
+    DEFAULT_CATEGORY_EXCEPTION(403, 3250, "기본 카테고리는 수정 또는 삭제가 불가능합니다."),
 
     // Channel (3300 ~ 3399)
     CHANNEL_NOT_FOUND(404, 3300, "채널을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🛠️ 구현 기능
  - 카테고리 삭제 API 구현

## 📝 구현 방법
  - 기본 카테고리를 삭제하려는 경우 예외처리
  - 삭제하려는 카테고리 하위에 있던 채널들을 기본 카테고리 하위로 이동시킴
  - 카테고리 삭제 시 카테고리 간 순서 재설정 → 이전 노드와 다음 노드끼리 연결시켜줌

## 🎯 Resolve
  - #19 #37 
