### PR TITLE
[Feat] 서버장 권한 위임 API / 서버 삭제 API / 채널 목록 조회 API 

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/climbing/entity/Climbing.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/entity/Climbing.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.climbing.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,14 +11,19 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.book.entity.Book;
+import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
+import org.bookwoori.core.domain.reviewEmoji.entity.ReviewEmoji;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.global.BaseTimeEntity;
 
@@ -59,6 +65,12 @@ public class Climbing extends BaseTimeEntity {
     @Column(name = "end_date")
     @NotNull
     private LocalDate endDate;
+
+    @OneToMany(mappedBy = "climbing", cascade = CascadeType.ALL)
+    private List<ClimbingMember> members = new ArrayList<>();
+
+    @OneToMany(mappedBy = "climbing", cascade = CascadeType.ALL)
+    private List<ReviewEmoji> emojis = new ArrayList<>();
 
     @Builder
     public Climbing(Long climbingId, Server server, Book book, String name, String description,

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -54,7 +54,7 @@ public class ClimbingMemberService {
     @Transactional(readOnly = true)
     public ClimbingMember getMemberInClimbing(Member member, Long climbingId) {
         return climbingMemberRepository.findByMemberAndClimbing_ClimbingId(member, climbingId)
-            .orElseThrow(() -> new CustomException(ErrorCode.CLIMBINGMEMBER_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(ErrorCode.CLIMBING_MEMBER_NOT_FOUND));
     }
 
     public void delegateClimbingRole(Long climbingId, Member currentMember,

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.climbing.facade.ClimbingFacade;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
 import org.bookwoori.core.domain.server.dto.request.ServerInfoUpdateRequestDto;
+import org.bookwoori.core.domain.server.dto.request.ServerRoleDelegateRequestDto;
 import org.bookwoori.core.domain.server.facade.ServerFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -72,6 +73,14 @@ public class ServerController {
     @GetMapping("/{serverId}/members")
     public ResponseEntity<?> getServerMemberList(@PathVariable final Long serverId) {
         return ResponseEntity.ok(serverFacade.getServerMemberList(serverId));
+    }
+
+    @Operation(summary = "서버장 권한 위임", description = "서버장 권한을 같은 서버의 다른 멤버에게 이전합니다.")
+    @PatchMapping("/{serverId}/members")
+    public ResponseEntity<?> delegateServerRole(@PathVariable final Long serverId,
+        @RequestBody @Valid ServerRoleDelegateRequestDto requestDto) {
+        serverFacade.delegateServerRole(serverId, requestDto);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "서버 나가기", description = "로그인한 유저를 해당 서버에서 나가게 합니다.")

--- a/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/controller/ServerController.java
@@ -61,6 +61,13 @@ public class ServerController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "서버 삭제", description = "서버를 삭제합니다.")
+    @DeleteMapping("/{serverId}")
+    public ResponseEntity<?> deleteServer(@PathVariable final Long serverId) {
+        serverFacade.deleteServer(serverId);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "서버 이미지 편집", description = "서버 이미지를 수정 또는 삭제합니다.")
     @PatchMapping(value = "/{serverId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> updateServerImage(@PathVariable final Long serverId,

--- a/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerRoleDelegateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/dto/request/ServerRoleDelegateRequestDto.java
@@ -1,0 +1,10 @@
+package org.bookwoori.core.domain.server.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ServerRoleDelegateRequestDto(
+    @NotNull
+    Long memberId
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/server/entity/Server.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/entity/Server.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.bookwoori.core.global.BaseTimeEntity;
 
@@ -45,6 +46,9 @@ public class Server extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "server", cascade = CascadeType.ALL)
     private List<Category> categories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "server", cascade = CascadeType.ALL)
+    private List<Climbing> climbingChannels = new ArrayList<>();
 
     @OneToMany(mappedBy = "server", cascade = CascadeType.ALL)
     private List<ServerMember> members = new ArrayList<>();

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -68,6 +68,7 @@ public class ServerFacade {
         channelService.makeDefaultChannels(category);
     }
 
+    @Transactional(readOnly = true)
     public ServerDetailsResponseDto getServerDetails(Long serverId) {
         Server server = serverService.getServerById(serverId);
         Member owner = serverMemberService.getOwner(server);
@@ -78,11 +79,13 @@ public class ServerFacade {
             currentMember.equals(owner));
     }
 
+    @Transactional(readOnly = true)
     public ServerMemberListResponseDto getServerMemberList(Long serverId) {
         Server server = serverService.getServerById(serverId);
         return new ServerMemberListResponseDto(serverMemberService.getAllMembersByServer(server));
     }
 
+    @Transactional(readOnly = true)
     public ServerCategoryListResponseDto getServerCategoryList(Long serverId) {
         Server server = serverService.getServerById(serverId);
         List<Category> categories = categoryService.getCategoriesWithChannels(server);
@@ -95,7 +98,7 @@ public class ServerFacade {
         return new ServerCategoryListResponseDto(categoryDtoList);
     }
 
-
+    @Transactional
     public String getOrCreateInviteCode(Long serverId) {
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
         String inviteCode = ops.get(String.valueOf(serverId));
@@ -109,6 +112,7 @@ public class ServerFacade {
         }
     }
 
+    @Transactional
     public void createServerMember(String inviteCode) {
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
 //        System.out.println(ops.get(inviteCode)); // 디버깅용
@@ -124,11 +128,10 @@ public class ServerFacade {
         } else {
             serverMemberService.saveServerMember(currentMember, server,
                 ServerRole.MEMBER); // 서버멤버 생성
-
         }
     }
 
-
+    @Transactional(readOnly = true)
     public ServerListResponseDto getServerList() {
         Member member = memberService.getCurrentMember();
         List<Server> servers = serverMemberService.getServerListByMember(member);

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -183,4 +183,16 @@ public class ServerFacade {
         Member newOwner = memberService.getMemberById(requestDto.memberId());
         serverMemberService.delegateServerRole(server, currentMember, newOwner);
     }
+
+    @Transactional
+    public void deleteServer(Long serverId) {
+        Server server = serverService.getServerById(serverId);
+        Member currentMember = memberService.getCurrentMember();
+
+        if (!serverMemberService.isOwner(currentMember, server)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        serverService.deleteServer(server);
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -15,6 +15,7 @@ import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
 import org.bookwoori.core.domain.server.dto.request.ServerInfoUpdateRequestDto;
+import org.bookwoori.core.domain.server.dto.request.ServerRoleDelegateRequestDto;
 import org.bookwoori.core.domain.server.dto.response.ServerCategoryListResponseDto;
 import org.bookwoori.core.domain.server.dto.response.ServerDetailsResponseDto;
 import org.bookwoori.core.domain.server.dto.response.ServerItemDto;
@@ -173,5 +174,13 @@ public class ServerFacade {
         }
 
         server.updateServerImg(s3Util.uploadImage(newImage, "server"));
+    }
+
+    @Transactional
+    public void delegateServerRole(Long serverId, ServerRoleDelegateRequestDto requestDto) {
+        Server server = serverService.getServerById(serverId);
+        Member currentMember = memberService.getCurrentMember();
+        Member newOwner = memberService.getMemberById(requestDto.memberId());
+        serverMemberService.delegateServerRole(server, currentMember, newOwner);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.server.facade;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -10,6 +11,7 @@ import org.bookwoori.core.domain.category.dto.response.CategoryResponseDto;
 import org.bookwoori.core.domain.category.entity.Category;
 import org.bookwoori.core.domain.category.service.CategoryService;
 import org.bookwoori.core.domain.channel.dto.response.ChannelResponseDto;
+import org.bookwoori.core.domain.channel.entity.Channel;
 import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
@@ -88,14 +90,37 @@ public class ServerFacade {
     @Transactional(readOnly = true)
     public ServerCategoryListResponseDto getServerCategoryList(Long serverId) {
         Server server = serverService.getServerById(serverId);
-        List<Category> categories = categoryService.getCategoriesWithChannels(server);
+        List<Category> categories = sortCategory(categoryService.getCategoriesWithChannels(server));
         List<CategoryResponseDto> categoryDtoList = categories.stream()
             .map(category -> {
-                List<ChannelResponseDto> channelDtoList = category.getChannels().stream()
+                List<ChannelResponseDto> channelDtoList = sortChannel(
+                    category.getChannels()).stream()
                     .map(ChannelResponseDto::from).toList();
                 return CategoryResponseDto.from(category, channelDtoList);
             }).collect(Collectors.toList());
         return new ServerCategoryListResponseDto(categoryDtoList);
+    }
+
+    private List<Category> sortCategory(List<Category> categories) {
+        List<Category> sortedList = new ArrayList<>();
+        Category currentCategory = categories.stream()
+            .filter(category -> category.getBeforeNode() == null).findFirst().orElse(null);
+        while (currentCategory != null) {
+            sortedList.add(currentCategory);
+            currentCategory = currentCategory.getNextNode();
+        }
+        return sortedList;
+    }
+
+    private List<Channel> sortChannel(List<Channel> channels) {
+        List<Channel> sortedList = new ArrayList<>();
+        Channel currentChannel = channels.stream()
+            .filter(channel -> channel.getBeforeNode() == null).findFirst().orElse(null);
+        while (currentChannel != null) {
+            sortedList.add(currentChannel);
+            currentChannel = currentChannel.getNextNode();
+        }
+        return sortedList;
     }
 
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
@@ -18,6 +18,10 @@ public class ServerService {
         return serverRepository.save(server);
     }
 
+    public void deleteServer(Server server) {
+        serverRepository.delete(server);
+    }
+
     @Transactional(readOnly = true)
     public Server getServerById(Long serverId) {
         return serverRepository.findById(serverId)

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/entity/ServerMember.java
@@ -48,4 +48,7 @@ public class ServerMember {
     @Enumerated(EnumType.STRING)
     private ServerRole role;
 
+    public void updateRole(ServerRole role) {
+        this.role = role;
+    }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -62,4 +62,22 @@ public class ServerMemberService {
         serverMemberRepository.deleteByServerAndMember(server, member);
     }
 
+    public ServerMember getByMemberAndServer(Member member, Server server) {
+        return serverMemberRepository.findByMemberAndServer(member, server)
+            .orElseThrow(() -> new CustomException(ErrorCode.SERVER_MEMBER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void delegateServerRole(Server server, Member from, Member to) {
+        ServerMember owner = getByMemberAndServer(from, server);
+
+        if (!owner.getRole().equals(ServerRole.OWNER)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        ServerMember newOwner = getByMemberAndServer(to, server);
+        owner.updateRole(ServerRole.MEMBER);
+        newOwner.updateRole(ServerRole.OWNER);
+    }
+
 }

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -39,14 +39,14 @@ public enum ErrorCode {
 
     // Member (3000 ~ 3099)
     MEMBER_NOT_FOUND(404, 3000, "사용자를 찾을 수 없습니다."),
-    SERVER_OWNER_NOT_FOUND(404, 3001, "서버 주인을 찾을 수 없습니다."),
-    MEMBER_INACTIVE(404, 3002, "이미 계정을 삭제한 멤버입니다."),
+    MEMBER_INACTIVE(404, 3001, "이미 계정을 삭제한 멤버입니다."),
 
     // Server (3100 ~ 3199)
     SERVER_NOT_FOUND(404, 3100, "서버를 찾을 수 없습니다."),
     ALREADY_JOINED_SERVER(409, 3101, "이미 참여하고 있는 서버입니다."),
     DELEGATION_REQUIRED(409, 3102, "해당 요청 처리를 위해서는 서버장 권한을 위임해야 합니다."),
     SERVER_MEMBER_NOT_FOUND(404, 3150, "해당 서버에 사용자가 존재하지 않습니다."),
+    SERVER_OWNER_NOT_FOUND(404, 3151, "서버 주인을 찾을 수 없습니다."),
 
     // Category (3200 ~ 3299)
     CATEGORY_NOT_FOUND(404, 3200, "카테고리를 찾을 수 없습니다."),
@@ -60,7 +60,7 @@ public enum ErrorCode {
     ALREADY_JOINED_CLIMBING(409, 3401, "이미 참여하고 있는 클라이밍 채널입니다."),
     CLIMBING_NOT_READY(409, 3402, "모집 중인 클라이밍 채널만 편집할 수 있습니다."),
     OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
-    CLIMBINGMEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
+    CLIMBING_MEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
     CLIMBING_NOT_RUNNING(409, 3405, "진행 중인 클라이밍이 아닙니다."),
 
     // Book (3500 ~ 3599)

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     SERVER_NOT_FOUND(404, 3100, "서버를 찾을 수 없습니다."),
     ALREADY_JOINED_SERVER(409, 3101, "이미 참여하고 있는 서버입니다."),
     DELEGATION_REQUIRED(409, 3102, "해당 요청 처리를 위해서는 서버장 권한을 위임해야 합니다."),
+    SERVER_MEMBER_NOT_FOUND(404, 3150, "해당 서버에 사용자가 존재하지 않습니다."),
 
     // Category (3200 ~ 3299)
     CATEGORY_NOT_FOUND(404, 3200, "카테고리를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🛠️ 구현 기능
  - **서버장 권한 위임 API** 구현
  - **서버 삭제 API** 구현
  - **채널 목록 조회 API** 수정 : 카테고리 및 채널 목록 조회 시 ID 순서가 아닌 사용자가 지정한 순서대로 조회되도록 수정

## 📝 구현 방법
  - 서버 삭제 → 물리적 삭제 (hard delete) 로 구현
    >  `@OneToMany`의 `cascade` 옵션을 통해 부모 객체(`Server`) 삭제 시 자식 객체(`Category` `Channel` `ServerMember` `Climbing` `ClimbingMember` `ReviewEmoji`)들이 모두 삭제되도록 함

## 🎯 Resolve
  - <details><summary>#19</summary>
    <p>

      #38    </p></details> 
  - <details><summary>#41</summary>
    <p>

    #48 </p></details>

- #15 