### PR TITLE
[Feat] 카테고리 위치 변경 API

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/category/controller/CategoryController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/controller/CategoryController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.category.dto.request.CategoryCreateRequestDto;
+import org.bookwoori.core.domain.category.dto.request.CategoryLocateRequestDto;
 import org.bookwoori.core.domain.category.dto.request.CategoryUpdateRequestDto;
 import org.bookwoori.core.domain.category.facade.CategoryFacade;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,14 @@ public class CategoryController {
     public ResponseEntity<?> updateCategoryName(@PathVariable final Long categoryId,
         @Valid @RequestBody CategoryUpdateRequestDto requestDto) {
         categoryFacade.updateCategoryName(categoryId, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "카테고리 위치 변경", description = "카테고리의 위치를 변경합니다.")
+    @PatchMapping("/{categoryId}/locate")
+    public ResponseEntity<?> locateCategory(@PathVariable final Long categoryId,
+        @Valid @RequestBody CategoryLocateRequestDto requestDto) {
+        categoryFacade.locateCategory(categoryId, requestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/dto/request/CategoryLocateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/dto/request/CategoryLocateRequestDto.java
@@ -1,0 +1,10 @@
+package org.bookwoori.core.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CategoryLocateRequestDto(
+    @NotNull
+    Long beforeCategoryId
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/entity/Category.java
@@ -87,6 +87,13 @@ public class Category {
         this.nextNode = null;
     }
 
+    public void disconnect() {
+        if (this.nextNode != null) {
+            this.nextNode.setBeforeNode(null);
+        }
+        this.nextNode = null;
+    }
+
     public void modifyName(String name) {
         this.name = name;
     }

--- a/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
@@ -1,8 +1,8 @@
 package org.bookwoori.core.domain.category.facade;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.category.dto.request.CategoryCreateRequestDto;
+import org.bookwoori.core.domain.category.dto.request.CategoryLocateRequestDto;
 import org.bookwoori.core.domain.category.dto.request.CategoryUpdateRequestDto;
 import org.bookwoori.core.domain.category.entity.Category;
 import org.bookwoori.core.domain.category.service.CategoryService;
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-@Log4j2
 public class CategoryFacade {
 
     private final ChannelService channelService;
@@ -53,5 +52,27 @@ public class CategoryFacade {
         //카테고리 순서 재설정
         categoryService.detach(categoryToDelete);
         categoryService.delete(categoryToDelete);
+    }
+
+    @Transactional
+    public void locateCategory(Long categoryId, CategoryLocateRequestDto requestDto) {
+        Category categoryToMove = categoryService.getCategoryById(categoryId);
+        Category beforeCategory = categoryService.getCategoryById(requestDto.beforeCategoryId());
+
+        if (categoryToMove.isDefault()) {
+            throw new CustomException(ErrorCode.DEFAULT_CATEGORY_EXCEPTION);
+        }
+
+        if (categoryToMove.getCategoryId().equals(beforeCategory.getCategoryId())) {
+            return;
+        }
+
+        //두 카테고리가 서로 다른 서버에 있을 경우 예외 처리
+        if (!categoryToMove.getServer().equals(beforeCategory.getServer())) {
+            throw new CustomException(ErrorCode.CATEGORY_LOCATE_EXCEPTION);
+        }
+
+        categoryService.detach(categoryToMove);
+        categoryService.insert(categoryToMove, beforeCategory);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
@@ -56,9 +56,21 @@ public class CategoryService {
             .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
+    @Transactional
     public void detach(Category category) {
         category.connectBeforeAndAfterNodes();
         categoryRepository.flush();
+    }
+
+    @Transactional
+    public void insert(Category categoryToInsert, Category beforeCategory) {
+        Category nextCategory = beforeCategory.getNextNode();
+        beforeCategory.disconnect();
+        categoryRepository.flush();
+        categoryToInsert.setBeforeNode(beforeCategory);
+        if (nextCategory != null) {
+            nextCategory.setBeforeNode(categoryToInsert);
+        }
     }
 
     public void delete(Category category) {

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
 
     // Category (3200 ~ 3299)
     CATEGORY_NOT_FOUND(404, 3200, "카테고리를 찾을 수 없습니다."),
+    CATEGORY_LOCATE_EXCEPTION(404, 3201, "카테고리 위치를 변경할 수 없습니다."),
     DEFAULT_CATEGORY_EXCEPTION(403, 3250, "기본 카테고리는 수정 또는 삭제가 불가능합니다."),
 
     // Channel (3300 ~ 3399)

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -50,7 +50,7 @@ public enum ErrorCode {
 
     // Category (3200 ~ 3299)
     CATEGORY_NOT_FOUND(404, 3200, "카테고리를 찾을 수 없습니다."),
-    CATEGORY_LOCATE_EXCEPTION(404, 3201, "카테고리 위치를 변경할 수 없습니다."),
+    CATEGORY_LOCATE_EXCEPTION(400, 3201, "카테고리 위치를 변경할 수 없습니다."),
     DEFAULT_CATEGORY_EXCEPTION(403, 3250, "기본 카테고리는 수정 또는 삭제가 불가능합니다."),
 
     // Channel (3300 ~ 3399)


### PR DESCRIPTION
## 🛠️ 구현 기능
  - **카테고리 위치 변경 API** 구현

## 📝 구현 방법

> URI : `/categories/{categoryId}/locate`
> `@PathVariable` 로 받은 카테고리 ID = 위치 변경하려는 타겟 카테고리 ID

> 요청 Body
> ```
> {
>   "beforeCategoryId":71
> }
> ```
> `@RequestBody` 로 받은 카테고리 ID = 옮긴 위치 바로 앞에 있는 카테고리 ID

- 요청 Body 로 받은 `beforeCategoryId` 값을 통해 이동하려는 위치 파악 → 카테고리들의 연관관계 (`beforeCategory` 와 `nextCategory` 필드) 를 조정함으로써 카테고리 위치 변경 구현
- 기본 카테고리 위치를 변경하려고 하는 경우 예외 처리
- 카테고리를 다른 서버의 카테고리 아래로 옮기려는 경우 예외 처리
- 요청으로 받은 `categoryId`와 `beforeCategoryId`가 서로 같은 경우 예외 처리

## 🎯 Resolve
  - #41 
  - close #50 