### PR TITLE
[Feat] RefreshToken Redis로 관리 

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/book/facade/BookFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/facade/BookFacade.java
@@ -1,89 +1,28 @@
 package org.bookwoori.core.domain.book.facade;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.book.dto.response.BookDetailResponseDto;
 import org.bookwoori.core.domain.book.dto.response.BookResponseDto;
 import org.bookwoori.core.domain.book.service.BookService;
-import org.bookwoori.core.global.exception.CustomException;
-import org.bookwoori.core.global.exception.ErrorCode;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 @Log4j2
 public class BookFacade {
 
-    private static final String ALADIN_API_URL_SEARCH = "http://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
-    private static final String ALADIN_API_URL_LOOKUP = "http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx";
     private final BookService bookService;
-    @Autowired
-    private final RestTemplate restTemplate;
-    @Autowired
-    private final ObjectMapper objectMapper;
-    @Value("${aladin.TTB_KEY}")
-    private String TTB_KEY; // 알라딘 API Key
 
-    public Object getBooksByKeyword(String keyword) {
-        String url = ALADIN_API_URL_SEARCH +
-            "?ttbkey=" + TTB_KEY +
-            "&Query=" + keyword +
-            "&QueryType=Keyword" +
-            "&MaxResults=100" +
-            "&start=1" +
-            "&SearchTarget=Book" +
-            "&output=js" +
-            "&Version=20131101";
-
-        String jsonResponse = restTemplate.getForObject(url, String.class);
-
-        List<BookResponseDto> bookList = new ArrayList<>();
-
-        try {
-            JsonNode root = objectMapper.readTree(jsonResponse);
-            JsonNode items = root.path("item");
-
-            if (items.isArray()) {
-                for (JsonNode item : items) {
-                    bookList.add(BookResponseDto.from(item));
-                }
-            }
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.ALADIN_API_EXCEPTION);
-        }
-
-        return bookList;
+    @Transactional(readOnly = true)
+    public List<BookResponseDto> getBooksByKeyword(String keyword) {
+        return bookService.getBooksByKeyword(keyword);
     }
 
-    public Object getBookByIsbn(String isbn13) {
-
-        String url = ALADIN_API_URL_LOOKUP + "?ttbkey=" + TTB_KEY +
-            "&itemIdType=ISBN13" +
-            "&ItemId=" + isbn13 +
-            "&output=js" +
-            "&Version=20131101";
-
-        String jsonResponse = restTemplate.getForObject(url, String.class);
-
-        try {
-            JsonNode root = objectMapper.readTree(jsonResponse);
-            JsonNode item = root.path("item").get(0);
-
-            if (item != null) {
-                return BookDetailResponseDto.from(item);
-            }
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.ALADIN_API_EXCEPTION);
-        }
-
-        return null; // 데이터가 없거나 오류 발생 시 null 반환
-
+    @Transactional(readOnly = true)
+    public BookDetailResponseDto getBookByIsbn(String isbn13) {
+        return bookService.getBookByIsbn(isbn13);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/service/BookService.java
@@ -1,13 +1,22 @@
 package org.bookwoori.core.domain.book.service;
 
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.book.dto.response.BookDetailResponseDto;
+import org.bookwoori.core.domain.book.dto.response.BookResponseDto;
 import org.bookwoori.core.domain.book.entity.Book;
 import org.bookwoori.core.domain.book.repository.BookRepository;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @Transactional
@@ -15,23 +24,81 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookService {
 
     private final BookRepository bookRepository;
+    private static final String ALADIN_API_URL_SEARCH = "http://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
+    private static final String ALADIN_API_URL_LOOKUP = "http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx";
+    private final BookService bookService;
+    @Autowired
+    private final RestTemplate restTemplate;
+    @Autowired
+    private final ObjectMapper objectMapper;
+    @Value("${aladin.TTB_KEY}")
+    private String TTB_KEY; // 알라딘 API Key
 
-    public Book getOrCreateBookByIsbn(String isbn) {
-        return bookRepository.findByIsbn13(isbn)
-            .orElseGet(() -> {
-                Book newBook = Book.builder()
-                    .isbn13(isbn)
-                    .title("테스트 제목")
-                    .author("테스트 저자 ")
-                    .publisher("테스트 출판사")
-                    .itemPage(0)
-                    .coverImg(null)
-                    .description(null)
-                    .build();
-                return bookRepository.save(newBook);
-            });
+    @Transactional(readOnly = true)
+    public List<BookResponseDto> getBooksByKeyword(String keyword) {
+        String url = ALADIN_API_URL_SEARCH +
+            "?ttbkey=" + TTB_KEY +
+            "&Query=" + keyword +
+            "&QueryType=Keyword" +
+            "&MaxResults=100" +
+            "&start=1" +
+            "&SearchTarget=Book" +
+            "&output=js" +
+            "&Version=20131101";
+
+        String jsonResponse = restTemplate.getForObject(url, String.class);
+
+        List<BookResponseDto> bookList = new ArrayList<>();
+
+        try {
+            JsonNode root = objectMapper.readTree(jsonResponse);
+            JsonNode items = root.path("item");
+
+            if (items.isArray()) {
+                for (JsonNode item : items) {
+                    bookList.add(BookResponseDto.from(item));
+                }
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ALADIN_API_EXCEPTION);
+        }
+
+        return bookList;
     }
 
+    @Transactional(readOnly = true)
+    public BookDetailResponseDto getBookByIsbn(String isbn13) {
+        String url = ALADIN_API_URL_LOOKUP + "?ttbkey=" + TTB_KEY +
+            "&itemIdType=ISBN13" +
+            "&ItemId=" + isbn13 +
+            "&output=js" +
+            "&Version=20131101";
+
+        String jsonResponse = restTemplate.getForObject(url, String.class);
+
+        try {
+            JsonNode root = objectMapper.readTree(jsonResponse);
+            JsonNode item = root.path("item").get(0);
+
+            if (item != null) {
+                return BookDetailResponseDto.from(item);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.ALADIN_API_EXCEPTION);
+        }
+
+        return null; // 데이터가 없거나 오류 발생 시 null 반환
+
+    }
+
+    public Book getOrCreateBookByIsbn(String isbn) {
+        Optional<Book> existingBook = bookRepository.findByIsbn13(isbn);
+        if (existingBook.isPresent()) {
+            return existingBook.get();
+        }
+        Book newBook = getBookByIsbn(isbn).toEntity();
+        return bookRepository.save(newBook);
+    }
 
     @Transactional(readOnly = true)
     public Book getBookById(Long bookId) {

--- a/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/controller/AuthController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bookwoori.core.domain.member.dto.request.TokenRequestDto;
 import org.bookwoori.core.domain.member.dto.response.LoginResponseDto;
 import org.bookwoori.core.domain.member.facade.AuthFacade;
 import org.bookwoori.core.global.exception.ErrorCode;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,25 +42,18 @@ public class AuthController {
 
     @Operation(summary = "토큰 재발급", description = "액세스 토큰 및 리프레쉬 토큰을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshAccessToken(
-        @CookieValue(name = "refreshToken") String refreshToken, HttpServletResponse response) {
-        try {
-            // accessToken과 refreshToken을 모두 재발급
-            Map<String, String> tokens = tokenProvider.renewAccessAndRefreshToken(refreshToken);
-            String newAccessToken = tokens.get("accessToken");
-            String newRefreshToken = tokens.get("refreshToken");
+    public ResponseEntity<?> refreshAccessToken(@RequestBody TokenRequestDto requestDto,
+        HttpServletResponse response) {
+        Map<String, String> tokens = authFacade.refreshAccessToken(requestDto);
+        String newAccessToken = tokens.get("accessToken");
+        String newRefreshToken = tokens.get("refreshToken");
 
-            // 새로운 refreshToken을 쿠키에 설정 (CookieUtil 사용)
-            cookieUtil.addCookie(response, "refreshToken", newRefreshToken,
-                CookieUtil.REFRESH_TOKEN_MAX_AGE);
-
-            // 응답: accessToken은 Authorization 헤더에 설정
-            return ResponseEntity.ok()
-                .header("Authorization", "Bearer " + newAccessToken)
-                .body("New access and refresh tokens issued");
-        } catch (IllegalArgumentException e) {
-            throw new TokenException(ErrorCode.INVALID_TOKEN);
-        }
+        // 새로운 refreshToken 쿠키에 저장
+        cookieUtil.addCookie(response, "refreshToken", newRefreshToken,
+            CookieUtil.REFRESH_TOKEN_MAX_AGE);
+        return ResponseEntity.ok()
+            .header("Authorization", "Bearer " + newAccessToken)
+            .body("New access and refresh tokens issued");
     }
 
 

--- a/core/src/main/java/org/bookwoori/core/domain/member/dto/request/TokenRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/dto/request/TokenRequestDto.java
@@ -1,0 +1,6 @@
+package org.bookwoori.core.domain.member.dto.request;
+
+public record TokenRequestDto(
+    String refreshToken) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/member/dto/response/TokenResponseDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/dto/response/TokenResponseDto.java
@@ -1,0 +1,10 @@
+package org.bookwoori.core.domain.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponseDto(
+    String accessToken
+) {
+
+}

--- a/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
@@ -1,25 +1,56 @@
 package org.bookwoori.core.domain.member.facade;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bookwoori.core.domain.member.dto.request.TokenRequestDto;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.global.exception.ErrorCode;
+import org.bookwoori.core.global.exception.TokenException;
+import org.bookwoori.core.global.jwt.TokenProvider;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional
 public class AuthFacade {
 
     private final MemberService memberService;
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
 
     public void deleteMember() {
         Member currentMember = memberService.getCurrentMember();
         currentMember.deleteMember();
     }
 
-    @Transactional(readOnly = true)
-    public void getMemberStatus(Long kakaoId) {
-        memberService.getMemberStatus(kakaoId);
+    public Map<String, String> refreshAccessToken(TokenRequestDto requestDto) {
+        Authentication authentication = tokenProvider.getAuthentication(requestDto.refreshToken(),
+            true);
+        Long kakaoId = tokenProvider.extractKakaoId(authentication);
+        // Redis에서 kakaoId를 key로 하는 refreshToken 가져옴
+        String storedRefreshToken = redisTemplate.opsForValue()
+            .get(kakaoId.toString());
+
+        log.info("Extracted kakaoId: {}", kakaoId);
+        log.info("Stored key in Redis: {}", redisTemplate.keys("*"));
+
+        // 전달받은 리프레시 토큰과 Redis에 저장된 리프레시 토큰이 일치하는지 확인
+        if (storedRefreshToken == null || !storedRefreshToken.equals(requestDto.refreshToken())) {
+            throw new TokenException(ErrorCode.INVALID_TOKEN);
+        }
+        // accessToken과 refreshToken을 모두 재발급
+        Map<String, String> tokens = tokenProvider.renewAccessAndRefreshToken(
+            requestDto.refreshToken());
+        String newRefreshToken = tokens.get("refreshToken");
+        // 새로운 refreshToken을 Redis에 설정
+        tokenProvider.saveRefreshToken(kakaoId, newRefreshToken);
+        return tokens;
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/repository/MemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/repository/MemberRepository.java
@@ -1,10 +1,15 @@
 package org.bookwoori.core.domain.member.repository;
 
+import java.util.Optional;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByKakaoId(Long kakaoId);
+
+    @Query("SELECT m.id FROM Member m WHERE m.kakaoId = :kakaoId")
+    Long findIdByKakaoId(@Param("kakaoId") Long kakaoId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/service/MemberService.java
@@ -32,7 +32,13 @@ public class MemberService {
         return member;
     }
 
-    public void getMemberStatus(Long kakaoId) {
+    @Transactional(readOnly = true)
+    public Long getMemberIdByKakaoId(Long kakaoId) {
+        return memberRepository.findIdByKakaoId(kakaoId);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateMemberStatus(Long kakaoId) {
         memberRepository.findByKakaoId(kakaoId)
             .filter(member -> member.getStatus() != Status.INACTIVE)
             .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_INACTIVE));

--- a/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
-//                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+//          .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(
@@ -92,7 +92,7 @@ public class SecurityConfig {
             .addFilterBefore(new TokenExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/success", "auth/refresh").permitAll()
+                .requestMatchers("/auth/success", "/auth/refresh").permitAll()
                 .anyRequest().authenticated())
             // 인증 예외 핸들링
             .exceptionHandling((exceptions) -> exceptions

--- a/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
+++ b/core/src/main/java/org/bookwoori/core/global/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
-//          .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .formLogin(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(

--- a/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
@@ -1,13 +1,19 @@
 package org.bookwoori.core.global.exception;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Log4j2
 public class TokenExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환을 위한 ObjectMapper
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -15,8 +21,24 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenException e) {
+            log.error("TokenException occurred: {}", e.getMessage(), e);
+
             ErrorCode errorCode = e.getErrorCode();
-            response.sendError(errorCode.getStatus(), errorCode.getMessage());
+            
+            ErrorDto errorDto = ErrorDto.builder()
+                .timestamp(LocalDateTime.now().toString())
+                .status(errorCode.getStatus())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .path(request.getRequestURI())
+                .build();
+
+            response.setStatus(errorDto.getStatus());
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            String responseJson = objectMapper.writeValueAsString(errorDto);
+            response.getWriter().write(responseJson);
         }
     }
 }

--- a/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/TokenExceptionFilter.java
@@ -24,7 +24,8 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
             log.error("TokenException occurred: {}", e.getMessage(), e);
 
             ErrorCode errorCode = e.getErrorCode();
-            
+
+            // ErrorDto 생성
             ErrorDto errorDto = ErrorDto.builder()
                 .timestamp(LocalDateTime.now().toString())
                 .status(errorCode.getStatus())
@@ -33,12 +34,15 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
                 .path(request.getRequestURI())
                 .build();
 
+            // HTTP 응답 설정
             response.setStatus(errorDto.getStatus());
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
 
+            // 에러 정보를 JSON으로 변환하여 응답에 작성
             String responseJson = objectMapper.writeValueAsString(errorDto);
             response.getWriter().write(responseJson);
         }
     }
+
 }

--- a/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
@@ -1,23 +1,17 @@
 package org.bookwoori.core.global.jwt;
 
-import org.bookwoori.core.global.exception.ErrorCode;
-import org.bookwoori.core.global.oauth.OAuth2UserInfo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
-import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.bookwoori.core.global.exception.TokenException;
-
-import java.io.IOException;
-
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @RequiredArgsConstructor
 @Component
@@ -27,7 +21,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+        FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = resolveToken(request);
         // accessToken 검증
@@ -39,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(String accessToken) {
-        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        Authentication authentication = tokenProvider.getAuthentication(accessToken, false);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/JwtAuthenticationFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.global.exception.ErrorCode;
+import org.bookwoori.core.global.exception.TokenException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -24,11 +26,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = resolveToken(request);
-        // accessToken 검증
-        if (accessToken != null && tokenProvider.validateToken(accessToken, false)) {
-            setAuthentication(accessToken);
+        if (accessToken != null) {
+            try {
+                if (tokenProvider.validateToken(accessToken, false)) {
+                    Authentication authentication = tokenProvider.getAuthentication(accessToken,
+                        false);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    throw new TokenException(ErrorCode.INVALID_TOKEN);
+                }
+            } catch (TokenException e) {
+                // TokenException을 던져서 TokenExceptionFilter에서 처리하게 함
+                throw e;
+            }
         }
-
         filterChain.doFilter(request, response);
     }
 

--- a/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
@@ -85,7 +85,7 @@ public class TokenProvider {
 
     public Map<String, String> renewAccessAndRefreshToken(String refreshToken) {
         if (validateToken(refreshToken, true)) {
-            Claims claims = parseClaims(refreshToken, refreshKey);
+            Claims claims = parseClaims(refreshToken, refreshKey, true);
             Long kakaoId = Long.valueOf(claims.getSubject());
             // 새 accessToken 및 refreshToken 생성
             List<String> roles = getRolesFromClaims(claims);
@@ -116,32 +116,26 @@ public class TokenProvider {
 
     public boolean validateToken(String token, boolean isRefreshToken) {
         try {
-            Claims claims = parseClaims(token, isRefreshToken ? refreshKey : accessKey);
+            Claims claims = parseClaims(token, isRefreshToken ? refreshKey : accessKey,
+                isRefreshToken);
             return claims.getExpiration().after(new Date());
         } catch (ExpiredJwtException e) {
-            if (isRefreshToken) {
-                throw new TokenException(ErrorCode.EXPIRED_REFRESH_TOKEN);
-            } else {
-                throw new TokenException(ErrorCode.EXPIRED_ACCESS_TOKEN);
-            }
+            throw new TokenException(
+                isRefreshToken ? ErrorCode.EXPIRED_REFRESH_TOKEN : ErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (io.jsonwebtoken.SignatureException e) {
+            throw new TokenException(ErrorCode.INVALID_JWT_SIGNATURE);
         } catch (JwtException e) {
             throw new TokenException(ErrorCode.INVALID_TOKEN);
         }
     }
 
     public Authentication getAuthentication(String token, boolean isRefreshToken) {
-        Claims claims;
-        if (isRefreshToken) {
-            claims = parseClaims(token, refreshKey);
-        } else {
-            claims = parseClaims(token, accessKey);
-        }
+        Claims claims = parseClaims(token, isRefreshToken ? refreshKey : accessKey, isRefreshToken);
         List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
         return new UsernamePasswordAuthenticationToken(claims.getSubject(), token, authorities);
     }
 
     public void saveRefreshToken(Long kakaoId, String refreshToken) {
-        Long memberId = memberService.getMemberIdByKakaoId(kakaoId);
         redisTemplate.opsForValue()
             .set(kakaoId.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
     }
@@ -157,7 +151,7 @@ public class TokenProvider {
             .collect(Collectors.toList());
     }
 
-    private Claims parseClaims(String token, SecretKey key) {
+    private Claims parseClaims(String token, SecretKey key, boolean isRefreshToken) {
         try {
             return Jwts.parser()
                 .setSigningKey(key)
@@ -165,11 +159,16 @@ public class TokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
         } catch (ExpiredJwtException e) {
-            return e.getClaims();
+            if (isRefreshToken) {
+                throw new TokenException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+            } else {
+                throw new TokenException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+            }
         } catch (JwtException e) {
             throw new TokenException(ErrorCode.INVALID_TOKEN);
         }
     }
+
 }
 
 

--- a/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
+++ b/core/src/main/java/org/bookwoori/core/global/jwt/TokenProvider.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -17,9 +18,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import org.bookwoori.core.domain.member.service.MemberService;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.bookwoori.core.global.exception.TokenException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -39,6 +42,8 @@ public class TokenProvider {
     private SecretKey refreshKey;
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60L * 24 * 7;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final MemberService memberService;
 
     @PostConstruct
     private void setSecretKey() {
@@ -97,11 +102,17 @@ public class TokenProvider {
     }
 
     public Long extractKakaoId(Authentication authentication) {
-        if (authentication.getPrincipal() instanceof OAuth2User oAuth2User) {
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof OAuth2User oAuth2User) {
             return Long.valueOf(oAuth2User.getAttributes().get("id").toString());
+        } else if (principal instanceof String) {
+            // UsernamePasswordAuthenticationToken의 경우
+            return Long.valueOf((String) principal);
+        } else {
+            throw new TokenException(ErrorCode.MEMBER_NOT_FOUND);
         }
-        throw new TokenException(ErrorCode.MEMBER_NOT_FOUND);
     }
+
 
     public boolean validateToken(String token, boolean isRefreshToken) {
         try {
@@ -118,10 +129,21 @@ public class TokenProvider {
         }
     }
 
-    public Authentication getAuthentication(String token) {
-        Claims claims = parseClaims(token, accessKey);
+    public Authentication getAuthentication(String token, boolean isRefreshToken) {
+        Claims claims;
+        if (isRefreshToken) {
+            claims = parseClaims(token, refreshKey);
+        } else {
+            claims = parseClaims(token, accessKey);
+        }
         List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
         return new UsernamePasswordAuthenticationToken(claims.getSubject(), token, authorities);
+    }
+
+    public void saveRefreshToken(Long kakaoId, String refreshToken) {
+        Long memberId = memberService.getMemberIdByKakaoId(kakaoId);
+        redisTemplate.opsForValue()
+            .set(kakaoId.toString(), refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     private List<String> getRolesFromClaims(Claims claims) {

--- a/core/src/main/java/org/bookwoori/core/global/oauth/OAuth2SuccessHandler.java
+++ b/core/src/main/java/org/bookwoori/core/global/oauth/OAuth2SuccessHandler.java
@@ -1,18 +1,19 @@
 package org.bookwoori.core.global.oauth;
 
-import org.bookwoori.core.domain.member.facade.AuthFacade;
-import org.bookwoori.core.global.jwt.TokenProvider;
-import org.bookwoori.core.global.jwt.CookieUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bookwoori.core.domain.member.facade.AuthFacade;
+import org.bookwoori.core.domain.member.service.MemberService;
+import org.bookwoori.core.global.jwt.CookieUtil;
+import org.bookwoori.core.global.jwt.TokenProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
-import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,25 +24,29 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final CookieUtil cookieUtil;
     private static final String URI = "/auth/success";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private final MemberService memberService;
     private final AuthFacade authFacade;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+        Authentication authentication) throws IOException, ServletException {
         // accessToken 발급
         String accessToken = tokenProvider.generateAccessToken(authentication);
         response.addHeader("Authorization", "Bearer " + accessToken);
 
         // refreshToken 발급 및 쿠키에 저장
-        Long kakoId = tokenProvider.extractKakaoId(authentication);
-        authFacade.getMemberStatus(kakoId); // 계정 삭제한 멤버 예외 처리
-        String refreshToken = tokenProvider.generateRefreshToken(kakoId);
-        cookieUtil.addCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, CookieUtil.REFRESH_TOKEN_MAX_AGE);
+        Long kakaoId = tokenProvider.extractKakaoId(authentication);
+        memberService.validateMemberStatus(kakaoId); // 계정 삭제한 멤버 예외 처리
+        String refreshToken = tokenProvider.generateRefreshToken(kakaoId);
+        cookieUtil.addCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken,
+            CookieUtil.REFRESH_TOKEN_MAX_AGE);
+        // refreshToken Redis에 저장
+        tokenProvider.saveRefreshToken(kakaoId, refreshToken);
 
         // 리다이렉트 URL 설정 및 accessToken 전달
         String redirectUrl = UriComponentsBuilder.fromUriString(URI)
-                .queryParam("accessToken", accessToken)
-                .build().toUriString();
+            .queryParam("accessToken", accessToken)
+            .build().toUriString();
 
         // refreshToken -> /auth/refresh 엔드포인트로 요청
         response.sendRedirect(redirectUrl);


### PR DESCRIPTION
## 🛠️ 구현 기능
  - RefreshToken을 Redis로 관리하는 코드 추가
  - TokenException이 ErrorDto를 사용하도록 코드 수정
  - 만료된 AccessToken으로 API 요청 시 UNAUTHORIZED 에러로 잡히는 오류 해결 
  - OAuth2SuccessHandler가 AuthFacade가 아닌 MemberService 의존하도록 수정
  - getMemberStatus() → validateMemberStatus()로 네이밍 변경
  - BookFacade, BookService 코드 수정 

## 🔥 구현 결과
  - RefreshToken Redis 저장 테스트 완료 ![image](https://github.com/user-attachments/assets/9a4124e6-1796-485d-b2f6-4a52bf2e69df)
  - 만료된 AccessToken으로 API 요청 Swagger 테스트 완료 ![image](https://github.com/user-attachments/assets/10e3f905-56e5-44ff-abe3-88e7d53e8a74)
  - 토큰 재발급 API 테스트 완료 
  ![image](https://github.com/user-attachments/assets/9039e013-926a-46c7-baef-54119e90fff3)

## 🎯 Resolve
  - #66 
