### PR TITLE
[Feat] 서버 정보 조회 API / 서버 삭제 API

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
@@ -1,6 +1,5 @@
 package org.bookwoori.core.domain.member.facade;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bookwoori.core.domain.member.dto.request.GetOrSaveMemberRequestDto;
@@ -22,13 +21,11 @@ public class AuthFacade {
 
     public void deleteMember() {
         Member currentMember = memberService.getCurrentMember();
-        Optional.ofNullable(currentMember.getProfileImg())
-            .ifPresent(s3Util::deleteImage);
-        Optional.ofNullable(currentMember.getBackgroundImg())
-            .ifPresent(s3Util::deleteImage);
+        s3Util.deleteImage(currentMember.getProfileImg());
+        s3Util.deleteImage(currentMember.getBackgroundImg());
         currentMember.deleteMember();
     }
-    
+
     public GetMemberResponseDto getOrSaveMemberByKakaoId(GetOrSaveMemberRequestDto requestDto) {
         boolean isMember = memberService.existsByKakaoId(requestDto.kakaoId());
         if (isMember) {

--- a/core/src/main/java/org/bookwoori/core/domain/member/facade/MemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/facade/MemberFacade.java
@@ -37,9 +37,8 @@ public class MemberFacade {
         if (oldImageUrl != null && s3Util.isSameImage(newImage, oldImageUrl)) {
             return oldImageUrl;
         }
-        if (oldImageUrl != null) {
-            s3Util.deleteImage(oldImageUrl);
-        }
+
+        s3Util.deleteImage(oldImageUrl);
         return s3Util.uploadImage(newImage, path);
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -250,6 +250,7 @@ public class ServerFacade {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
+        s3Util.deleteImage(server.getServerImg());
         serverService.deleteServer(server);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -28,7 +28,6 @@ import org.bookwoori.core.domain.server.dto.response.ServerMemberListResponseDto
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
-import org.bookwoori.core.domain.serverMember.repository.ServerMemberRepository;
 import org.bookwoori.core.domain.serverMember.service.ServerMemberService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
@@ -52,7 +51,6 @@ public class ServerFacade {
     private final CategoryService categoryService;
     private final ChannelService channelService;
     private final ServerMemberService serverMemberService;
-    private final ServerMemberRepository serverMemberRepository;
 
     @Transactional
     public void createServer(ServerCreateRequestDto requestDto) {
@@ -78,6 +76,10 @@ public class ServerFacade {
         Member owner = serverMemberService.getOwner(server);
         int memberCount = serverMemberService.getMemberCount(server);
         Member currentMember = memberService.getCurrentMember();
+
+        if (!serverMemberService.isJoined(currentMember, server)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         return ServerDetailsResponseDto.from(server, owner.getNickname(), memberCount,
             currentMember.equals(owner));
@@ -175,8 +177,7 @@ public class ServerFacade {
         Server server = serverService.getServerById(serverId);
         Member currentMember = memberService.getCurrentMember();
 
-        boolean isJoined = serverMemberRepository.findByMemberAndServer(currentMember, server)
-            .isPresent();
+        boolean isJoined = serverMemberService.isJoined(currentMember, server);
 
         if (isJoined) {
             throw new CustomException(ErrorCode.ALREADY_JOINED_SERVER);

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -228,9 +228,7 @@ public class ServerFacade {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
-        if (server.getServerImg() != null) {
-            s3Util.deleteImage(server.getServerImg());
-        }
+        s3Util.deleteImage(server.getServerImg());
 
         server.updateServerImg(s3Util.uploadImage(newImage, "server"));
     }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/repository/ServerMemberRepository.java
@@ -13,6 +13,9 @@ public interface ServerMemberRepository extends JpaRepository<ServerMember, Long
 
     int countByServer(Server server);
 
+    @Query("SELECT COUNT(sm) > 0 FROM ServerMember sm WHERE sm.member = :member AND sm.server = :server")
+    boolean existsByMemberAndServer(Member member, Server server);
+
     @Query("SELECT COUNT(sm) > 0 FROM ServerMember sm WHERE sm.member = :member AND sm.server = :server AND sm.role = 'OWNER'")
     boolean existsByMemberAndServerAndRole(Member member, Server server);
 

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -30,6 +30,11 @@ public class ServerMemberService {
     }
 
     @Transactional(readOnly = true)
+    public boolean isJoined(Member member, Server server) {
+        return serverMemberRepository.existsByMemberAndServer(member, server);
+    }
+
+    @Transactional(readOnly = true)
     public boolean isOwner(Member member, Server server) {
         return serverMemberRepository.existsByMemberAndServerAndRole(member, server);
     }

--- a/core/src/main/java/org/bookwoori/core/global/s3/S3Util.java
+++ b/core/src/main/java/org/bookwoori/core/global/s3/S3Util.java
@@ -52,6 +52,11 @@ public class S3Util {
     }
 
     public void deleteImage(String url) {
+
+        if (url == null || !url.startsWith("https://" + bucket)) {
+            return;
+        }
+
         String delimiter = ".com/";
         int index = url.lastIndexOf(delimiter);
         if (index == -1) {


### PR DESCRIPTION
## 🛠️ 구현 기능
  - **서버 정보 조회 API** 수정
    > 접근 권한 검사 및 403 예외 응답 추가
  - **서버 삭제 API** 수정 
    > 서버 삭제 시 버킷에서 이미지 파일 삭제
  - S3Util `deleteImage()` 리팩토링
    > 매개변수 `url` 의 유효성을 메서드 내에서 검사 (url이 `null`이거나 버킷 주소로 시작하지 않는 경우 return) → 메서드 호출 시 null 검사를 진행하지 않아도 됨

## 🎯 Resolve
  - close #9 #38 
