### PR TITLE
[Feat] 카프카 그룹 설정 / 채팅 답장 응답 수정

### DIFF
--- a/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/dto/request/ChannelMessageReplyRequestDto.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/dto/request/ChannelMessageReplyRequestDto.java
@@ -12,7 +12,7 @@ public record ChannelMessageReplyRequestDto(
     String content
 ) {
 
-    public ChannelMessage toEntity(Long memberId, String parentContent) {
+    public ChannelMessage toEntity(Long memberId, ChannelMessage parentMessage) {
         return ChannelMessage.builder()
             .parentId(this.parentId)
             .channelId(this.channelId)
@@ -20,7 +20,8 @@ public record ChannelMessageReplyRequestDto(
             .type(this.type)
             .content(this.content)
             .createdAt(LocalDateTime.now())
-            .parentContent(parentContent)
+            .parentMemberId(parentMessage.getMemberId())
+            .parentContent(parentMessage.getContent())
             .eventType(EventType.REPLY)
             .build();
     }

--- a/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/dto/response/ChannelMessageReplyResponseDto.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/dto/response/ChannelMessageReplyResponseDto.java
@@ -16,6 +16,7 @@ public record ChannelMessageReplyResponseDto(
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime createdAt,
     String parentId,
+    Long parentMemberId,
     String parentContent
 ) {
 
@@ -28,6 +29,7 @@ public record ChannelMessageReplyResponseDto(
             .content(channelMessage.getContent())
             .createdAt(channelMessage.getCreatedAt())
             .parentId(channelMessage.getParentId())
+            .parentMemberId(channelMessage.getParentMemberId())
             .parentContent(channelMessage.getParentContent())
             .build();
     }

--- a/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/entity/ChannelMessage.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/channelMessage/entity/ChannelMessage.java
@@ -47,6 +47,9 @@ public class ChannelMessage {
      * 데이터베이스에 저장되지 않는 필드
      */
     @Transient
+    private Long parentMemberId;
+
+    @Transient
     private String parentContent;
 
     @Transient

--- a/chat/src/main/java/org/bookwoori/chat/domain/directMessage/dto/request/DirectMessageReplyRequestDto.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/directMessage/dto/request/DirectMessageReplyRequestDto.java
@@ -12,7 +12,7 @@ public record DirectMessageReplyRequestDto(
     String content
 ) {
 
-    public DirectMessage toEntity(Long memberId, String parentContent) {
+    public DirectMessage toEntity(Long memberId, DirectMessage parentMessage) {
         return DirectMessage.builder()
             .parentId(this.parentId)
             .messageRoomId(this.messageRoomId)
@@ -20,7 +20,8 @@ public record DirectMessageReplyRequestDto(
             .type(this.type)
             .content(this.content)
             .createdAt(LocalDateTime.now())
-            .parentContent(parentContent)
+            .parentMemberId(parentMessage.getMemberId())
+            .parentContent(parentMessage.getContent())
             .eventType(EventType.REPLY)
             .build();
     }

--- a/chat/src/main/java/org/bookwoori/chat/domain/directMessage/dto/response/DirectMessageReplyResponseDto.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/directMessage/dto/response/DirectMessageReplyResponseDto.java
@@ -16,6 +16,7 @@ public record DirectMessageReplyResponseDto(
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime createdAt,
     String parentId,
+    Long parentMemberId,
     String parentContent
 ) {
 
@@ -28,6 +29,7 @@ public record DirectMessageReplyResponseDto(
             .content(directMessage.getContent())
             .createdAt(directMessage.getCreatedAt())
             .parentId(directMessage.getParentId())
+            .parentMemberId(directMessage.getParentMemberId())
             .parentContent(directMessage.getParentContent())
             .build();
     }

--- a/chat/src/main/java/org/bookwoori/chat/domain/directMessage/entity/DirectMessage.java
+++ b/chat/src/main/java/org/bookwoori/chat/domain/directMessage/entity/DirectMessage.java
@@ -47,6 +47,9 @@ public class DirectMessage {
      * 데이터베이스에 저장되지 않는 필드
      */
     @Transient
+    private Long parentMemberId;
+
+    @Transient
     private String parentContent;
 
     @Transient

--- a/chat/src/main/java/org/bookwoori/chat/global/kafka/KafkaConsumerConfig.java
+++ b/chat/src/main/java/org/bookwoori/chat/global/kafka/KafkaConsumerConfig.java
@@ -2,6 +2,7 @@ package org.bookwoori.chat.global.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,8 +30,9 @@ public class KafkaConsumerConfig {
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
+        String uuid = UUID.randomUUID().toString();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId + uuid);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");

--- a/chat/src/main/java/org/bookwoori/chat/global/kafka/MessageSender.java
+++ b/chat/src/main/java/org/bookwoori/chat/global/kafka/MessageSender.java
@@ -54,8 +54,7 @@ public class MessageSender { //토픽에 이벤트를 발행
     public void replyToDirectMessage(DirectMessageReplyRequestDto requestDto, Long memberId) {
         DirectMessage parentDirectMessage = directMessageRepository.findById(requestDto.parentId())
             .orElseThrow(() -> new CustomException(ErrorCode.DIRECT_MESSAGE_NOT_FOUND));
-        DirectMessage directMessage = requestDto.toEntity(memberId,
-            parentDirectMessage.getContent());
+        DirectMessage directMessage = requestDto.toEntity(memberId, parentDirectMessage);
         directMessageRepository.save(directMessage);
         kafkaTemplate.send(KafkaConstants.DIRECT_CHAT_EVENT_TOPIC, directMessage);
     }

--- a/chat/src/main/java/org/bookwoori/chat/global/kafka/MessageSender.java
+++ b/chat/src/main/java/org/bookwoori/chat/global/kafka/MessageSender.java
@@ -119,8 +119,7 @@ public class MessageSender { //토픽에 이벤트를 발행
         ChannelMessage parentChannelMessage = channelMessageRepository.findById(
                 requestDto.parentId())
             .orElseThrow(() -> new CustomException(ErrorCode.CHANNEL_MESSAGE_NOT_FOUND));
-        ChannelMessage channelMessage = requestDto.toEntity(memberId,
-            parentChannelMessage.getContent());
+        ChannelMessage channelMessage = requestDto.toEntity(memberId, parentChannelMessage);
         channelMessageRepository.save(channelMessage);
         kafkaTemplate.send(KafkaConstants.CHANNEL_CHAT_EVENT_TOPIC, channelMessage);
     }


### PR DESCRIPTION
## 🛠️ PR 요약
  - DM/채널 채팅 답장 응답 수정 (`parentMemberId` 필드 추가)
  - 서버마다 카프카 Group Id 를 다르게 지정 → 카프카를 통해 다중 서버 간 메시지를 중계하도록 함

## 🎯 Resolve
  - #75 #84 
