### PR TITLE
[Refactor] Server, Category, Channel, ServerMember, MessageRoom

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
@@ -22,6 +22,7 @@ public class CategoryFacade {
     private final CategoryServiceImpl categoryService;
     private final ServerServiceImpl serverService;
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void createCategory(CategoryCreateRequestDto requestDto) {
         Server server = serverService.getServerById(requestDto.serverId());
@@ -37,6 +38,7 @@ public class CategoryFacade {
         category.modifyName(requestDto.name());
     }
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void deleteCategory(Long categoryId) {
         Category categoryToDelete = categoryService.getCategoryWithChannels(categoryId);
@@ -54,6 +56,7 @@ public class CategoryFacade {
         categoryService.delete(categoryToDelete);
     }
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void locateCategory(Long categoryId, CategoryLocateRequestDto requestDto) {
         Category categoryToMove = categoryService.getCategoryById(categoryId);

--- a/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
@@ -5,10 +5,10 @@ import org.bookwoori.core.domain.category.dto.request.CategoryCreateRequestDto;
 import org.bookwoori.core.domain.category.dto.request.CategoryLocateRequestDto;
 import org.bookwoori.core.domain.category.dto.request.CategoryUpdateRequestDto;
 import org.bookwoori.core.domain.category.entity.Category;
-import org.bookwoori.core.domain.category.service.CategoryServiceImpl;
-import org.bookwoori.core.domain.channel.service.ChannelServiceImpl;
+import org.bookwoori.core.domain.category.service.CategoryService;
+import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.domain.server.entity.Server;
-import org.bookwoori.core.domain.server.service.ServerServiceImpl;
+import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
@@ -18,9 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CategoryFacade {
 
-    private final ChannelServiceImpl channelService;
-    private final CategoryServiceImpl categoryService;
-    private final ServerServiceImpl serverService;
+    private final ChannelService channelService;
+    private final CategoryService categoryService;
+    private final ServerService serverService;
 
     /* TODO @crHwang0822 리팩토링 */
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/facade/CategoryFacade.java
@@ -28,7 +28,7 @@ public class CategoryFacade {
         Category category = requestDto.toEntity(server);
         Category beforeCategory = categoryService.getLastNodeByServer(server);
         category.setBeforeNode(beforeCategory);
-        categoryService.saveCategory(category);
+        categoryService.save(category);
     }
 
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryService.java
@@ -1,5 +1,28 @@
 package org.bookwoori.core.domain.category.service;
 
+import java.util.List;
+import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.server.entity.Server;
+
 public interface CategoryService {
 
+    Category save(Category category);
+
+    Category makeDefaultCategory(Server server);
+
+    Category getDefaultCategoryByServer(Server server);
+
+    Category getLastNodeByServer(Server server);
+
+    Category getCategoryById(Long categoryId);
+
+    List<Category> getCategoriesWithChannels(Server server);
+
+    Category getCategoryWithChannels(Long categoryId);
+
+    void detach(Category category);
+
+    void insert(Category categoryToInsert, Category beforeCategory);
+
+    void delete(Category category);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/category/service/CategoryServiceImpl.java
@@ -16,7 +16,7 @@ public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
 
-    public Category saveCategory(Category category) {
+    public Category save(Category category) {
         return categoryRepository.save(category);
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
@@ -19,6 +19,7 @@ public class ChannelFacade {
     private final ChannelServiceImpl channelService;
     private final CategoryServiceImpl categoryService;
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void createChannel(ChannelCreateRequestDto requestDto) {
         Category category = categoryService.getCategoryById(requestDto.categoryId());
@@ -28,6 +29,7 @@ public class ChannelFacade {
         channelService.save(channel);
     }
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void modifyChannel(Long channelId, ChannelModifyRequestDto requestDto) {
         Channel channel = channelService.getChannelById(channelId);
@@ -48,6 +50,7 @@ public class ChannelFacade {
         channel.modifyName(requestDto.name());
     }
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void deleteChannel(Long channelId) {
         Channel channel = channelService.getChannelById(channelId);

--- a/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
@@ -25,7 +25,7 @@ public class ChannelFacade {
         Channel channel = requestDto.toEntity(category);
         Channel beforeChannel = channelService.getLastNodeByCategory(category);
         channel.setBeforeNode(beforeChannel);
-        channelService.saveChannel(channel);
+        channelService.save(channel);
     }
 
     @Transactional
@@ -52,6 +52,6 @@ public class ChannelFacade {
     public void deleteChannel(Long channelId) {
         Channel channel = channelService.getChannelById(channelId);
         channelService.detach(channel);
-        channelService.deleteChannel(channel);
+        channelService.delete(channel);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/facade/ChannelFacade.java
@@ -2,11 +2,11 @@ package org.bookwoori.core.domain.channel.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.category.entity.Category;
-import org.bookwoori.core.domain.category.service.CategoryServiceImpl;
+import org.bookwoori.core.domain.category.service.CategoryService;
 import org.bookwoori.core.domain.channel.dto.request.ChannelCreateRequestDto;
 import org.bookwoori.core.domain.channel.dto.request.ChannelModifyRequestDto;
 import org.bookwoori.core.domain.channel.entity.Channel;
-import org.bookwoori.core.domain.channel.service.ChannelServiceImpl;
+import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
@@ -16,8 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChannelFacade {
 
-    private final ChannelServiceImpl channelService;
-    private final CategoryServiceImpl categoryService;
+    private final ChannelService channelService;
+    private final CategoryService categoryService;
 
     /* TODO @crHwang0822 리팩토링 */
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelService.java
@@ -1,5 +1,23 @@
 package org.bookwoori.core.domain.channel.service;
 
+import org.bookwoori.core.domain.category.entity.Category;
+import org.bookwoori.core.domain.channel.entity.Channel;
+
 public interface ChannelService {
 
+    Channel save(Channel channel);
+
+    void makeDefaultChannels(Category category);
+
+    void delete(Channel channel);
+
+    Channel getLastNodeByCategory(Category category);
+
+    Channel getFirstNodeByCategory(Category category);
+
+    Channel getChannelById(Long channelId);
+
+    void detach(Channel channel);
+
+    void moveChannelsToCategory(Category from, Category to);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/channel/service/ChannelServiceImpl.java
@@ -16,7 +16,7 @@ public class ChannelServiceImpl implements ChannelService {
 
     private final ChannelRepository channelRepository;
 
-    public Channel saveChannel(Channel channel) {
+    public Channel save(Channel channel) {
         return channelRepository.save(channel);
     }
 
@@ -36,7 +36,7 @@ public class ChannelServiceImpl implements ChannelService {
         channelRepository.save(voiceChannel);
     }
 
-    public void deleteChannel(Channel channel) {
+    public void delete(Channel channel) {
         channelRepository.delete(channel);
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/facade/AuthFacade.java
@@ -12,7 +12,7 @@ import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.service.ServerMemberServiceImpl;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
-import org.bookwoori.core.global.s3.S3Util;
+import org.bookwoori.core.global.util.S3Util;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/core/src/main/java/org/bookwoori/core/domain/member/facade/MemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/facade/MemberFacade.java
@@ -8,7 +8,7 @@ import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.service.MemberServiceImpl;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
-import org.bookwoori.core.global.s3.S3Util;
+import org.bookwoori.core.global.util.S3Util;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;

--- a/core/src/main/java/org/bookwoori/core/domain/messageRoom/facade/MessageRoomFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/messageRoom/facade/MessageRoomFacade.java
@@ -7,13 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.member.dto.response.MemberProfileResponseDto;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.member.entity.Status;
-import org.bookwoori.core.domain.member.service.MemberServiceImpl;
+import org.bookwoori.core.domain.member.service.MemberService;
 import org.bookwoori.core.domain.messageRoom.dto.request.MessageRoomCreateRequestDto;
 import org.bookwoori.core.domain.messageRoom.dto.response.MessageRoomDetailsResponseDto;
 import org.bookwoori.core.domain.messageRoom.dto.response.MessageRoomItemDto;
 import org.bookwoori.core.domain.messageRoom.dto.response.MessageRoomListResponseDto;
 import org.bookwoori.core.domain.messageRoom.entity.MessageRoom;
-import org.bookwoori.core.domain.messageRoom.service.MessageRoomServiceImpl;
+import org.bookwoori.core.domain.messageRoom.service.MessageRoomService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.bookwoori.core.global.feignClient.ChatClient;
@@ -30,8 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MessageRoomFacade {
 
     private final ChatClient chatClient;
-    private final MessageRoomServiceImpl messageRoomService;
-    private final MemberServiceImpl memberService;
+    private final MessageRoomService messageRoomService;
+    private final MemberService memberService;
 
     @Transactional
     public MessageRoomDetailsResponseDto getOrCreateMessageRoom(

--- a/core/src/main/java/org/bookwoori/core/domain/messageRoom/service/MessageRoomService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/messageRoom/service/MessageRoomService.java
@@ -1,5 +1,15 @@
 package org.bookwoori.core.domain.messageRoom.service;
 
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.messageRoom.entity.MessageRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface MessageRoomService {
 
+    MessageRoom save(MessageRoom messageRoom);
+
+    MessageRoom getOrCreateMessageRoom(Member sender, Member receiver);
+
+    Page<MessageRoom> getMessageRoomsByMember(Member member, Pageable pageable);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/messageRoom/service/MessageRoomServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/messageRoom/service/MessageRoomServiceImpl.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.messageRoom.entity.MessageRoom;
 import org.bookwoori.core.domain.messageRoom.repository.MessageRoomRepository;
-import org.bookwoori.core.global.exception.CustomException;
-import org.bookwoori.core.global.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,22 +14,18 @@ public class MessageRoomServiceImpl implements MessageRoomService {
 
     private final MessageRoomRepository messageRoomRepository;
 
-    public MessageRoom saveMessageRoom(MessageRoom messageRoom) {
+    public MessageRoom save(MessageRoom messageRoom) {
         return messageRoomRepository.save(messageRoom);
     }
 
     public MessageRoom getOrCreateMessageRoom(Member sender, Member receiver) {
         return messageRoomRepository.getMessageRoomByMembers(sender, receiver)
-            .orElseGet(() -> saveMessageRoom(MessageRoom.builder()
+            .orElseGet(() -> save(MessageRoom.builder()
                 .sender(sender)
                 .receiver(receiver)
                 .build()));
     }
 
-    public MessageRoom getMessageRoomById(Long messageRoomId) {
-        return messageRoomRepository.findById(messageRoomId)
-            .orElseThrow(() -> new CustomException(ErrorCode.MESSAGE_ROOM_NOT_FOUND));
-    }
 
     public Page<MessageRoom> getMessageRoomsByMember(Member member, Pageable pageable) {
         return messageRoomRepository.getMessageRoomsByMember(member, pageable);

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -63,7 +63,7 @@ public class ServerFacade {
         //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요
         Member member = memberService.getCurrentMember();
         //서버장을 ServerMember 테이블에 추가
-        serverMemberService.saveServerMember(member, server, ServerRole.OWNER);
+        serverMemberService.save(member, server, ServerRole.OWNER);
 
         //DEFAULT 카테고리/채널 생성 및 저장
         Category category = categoryService.makeDefaultCategory(server);
@@ -181,7 +181,7 @@ public class ServerFacade {
         if (isJoined) {
             throw new CustomException(ErrorCode.ALREADY_JOINED_SERVER);
         } else {
-            serverMemberService.saveServerMember(currentMember, server,
+            serverMemberService.save(currentMember, server,
                 ServerRole.MEMBER); // 서버멤버 생성
         }
     }
@@ -203,7 +203,7 @@ public class ServerFacade {
             throw new CustomException(ErrorCode.DELEGATION_REQUIRED);
         }
 
-        serverMemberService.deleteServerMember(server, member);
+        serverMemberService.delete(server, member);
     }
 
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -10,12 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.category.dto.response.CategoryResponseDto;
 import org.bookwoori.core.domain.category.entity.Category;
-import org.bookwoori.core.domain.category.service.CategoryServiceImpl;
+import org.bookwoori.core.domain.category.service.CategoryService;
 import org.bookwoori.core.domain.channel.dto.response.ChannelResponseDto;
 import org.bookwoori.core.domain.channel.entity.Channel;
-import org.bookwoori.core.domain.channel.service.ChannelServiceImpl;
+import org.bookwoori.core.domain.channel.service.ChannelService;
 import org.bookwoori.core.domain.member.entity.Member;
-import org.bookwoori.core.domain.member.service.MemberServiceImpl;
+import org.bookwoori.core.domain.member.service.MemberService;
 import org.bookwoori.core.domain.server.dto.request.ServerCreateRequestDto;
 import org.bookwoori.core.domain.server.dto.request.ServerInfoUpdateRequestDto;
 import org.bookwoori.core.domain.server.dto.request.ServerRoleDelegateRequestDto;
@@ -27,10 +27,10 @@ import org.bookwoori.core.domain.server.dto.response.ServerItemDto;
 import org.bookwoori.core.domain.server.dto.response.ServerListResponseDto;
 import org.bookwoori.core.domain.server.dto.response.ServerMemberListResponseDto;
 import org.bookwoori.core.domain.server.entity.Server;
-import org.bookwoori.core.domain.server.service.ServerServiceImpl;
+import org.bookwoori.core.domain.server.service.ServerService;
 import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
-import org.bookwoori.core.domain.serverMember.service.ServerMemberServiceImpl;
+import org.bookwoori.core.domain.serverMember.service.ServerMemberService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 import org.bookwoori.core.global.s3.S3Util;
@@ -48,11 +48,11 @@ public class ServerFacade {
     private final S3Util s3Util;
     private final StringRedisTemplate redisTemplate;
 
-    private final ServerServiceImpl serverService;
-    private final MemberServiceImpl memberService;
-    private final CategoryServiceImpl categoryService;
-    private final ChannelServiceImpl channelService;
-    private final ServerMemberServiceImpl serverMemberService;
+    private final ServerService serverService;
+    private final MemberService memberService;
+    private final CategoryService categoryService;
+    private final ChannelService channelService;
+    private final ServerMemberService serverMemberService;
 
     /* TODO @crHwang0822 리팩토링 */
     @Transactional

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -1,13 +1,13 @@
 package org.bookwoori.core.domain.server.facade;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.bookwoori.core.domain.category.dto.response.CategoryResponseDto;
 import org.bookwoori.core.domain.category.entity.Category;
 import org.bookwoori.core.domain.category.service.CategoryService;
@@ -33,20 +33,19 @@ import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.service.ServerMemberService;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
-import org.bookwoori.core.global.s3.S3Util;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.bookwoori.core.global.util.RedisUtil;
+import org.bookwoori.core.global.util.S3Util;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
-@Log4j2
+@Builder
 public class ServerFacade {
 
     private final S3Util s3Util;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisUtil redisUtil;
 
     private final ServerService serverService;
     private final MemberService memberService;
@@ -136,7 +135,6 @@ public class ServerFacade {
 
     @Transactional
     public String createInviteCode(Long serverId) {
-        ValueOperations<String, String> ops = redisTemplate.opsForValue();
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
         Random random = new Random();
@@ -146,17 +144,17 @@ public class ServerFacade {
 
         String inviteCode = uuid.substring(startIndex, endIndex);
 
-        ops.set("server:invitation:" + inviteCode, String.valueOf(serverId), 1,
-            TimeUnit.DAYS); // Redis에 저장, TTL 1일
+        // Redis에 저장, TTL 1일
+        redisUtil.setValuesWithTimeout("server:invitation:" + inviteCode, String.valueOf(serverId),
+            Duration.ofDays(1));
+
         return inviteCode;
     }
 
     @Transactional(readOnly = true)
     public InviteCodeServerResponseDto getServerByInviteCode(String inviteCode) {
+        String value = (String) redisUtil.getValues("server:invitation:" + inviteCode);
 
-        ValueOperations<String, String> ops = redisTemplate.opsForValue();
-
-        String value = ops.get("server:invitation:" + inviteCode);
         if (value == null) {
             throw new CustomException(ErrorCode.INVALID_INVITE_CODE);
         }
@@ -171,9 +169,8 @@ public class ServerFacade {
 
     @Transactional
     public void createServerMember(String inviteCode) {
-        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        String value = (String) redisUtil.getValues("server:invitation:" + inviteCode);
 
-        String value = ops.get("server:invitation:" + inviteCode);
         if (value == null) {
             throw new CustomException(ErrorCode.INVALID_INVITE_CODE);
         }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -58,7 +58,7 @@ public class ServerFacade {
         //서버 저장
         Server server = requestDto.toEntity(
             s3Util.uploadImage(requestDto.serverImg(), "server"));
-        serverService.saveServer(server);
+        serverService.save(server);
 
         //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요
         Member member = memberService.getCurrentMember();
@@ -129,7 +129,7 @@ public class ServerFacade {
     }
 
     @Transactional
-    public Object createInviteCode(Long serverId) {
+    public String createInviteCode(Long serverId) {
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
@@ -143,11 +143,10 @@ public class ServerFacade {
         ops.set("server:invitation:" + inviteCode, String.valueOf(serverId), 1,
             TimeUnit.DAYS); // Redis에 저장, TTL 1일
         return inviteCode;
-
     }
 
     @Transactional(readOnly = true)
-    public Object getServerByInviteCode(String inviteCode) {
+    public InviteCodeServerResponseDto getServerByInviteCode(String inviteCode) {
 
         ValueOperations<String, String> ops = redisTemplate.opsForValue();
 
@@ -162,7 +161,6 @@ public class ServerFacade {
         int memberCount = serverMemberService.getMemberCount(server);
 
         return InviteCodeServerResponseDto.from(server, owner.getNickname(), memberCount);
-
     }
 
     @Transactional
@@ -252,6 +250,6 @@ public class ServerFacade {
         }
 
         s3Util.deleteImage(server.getServerImg());
-        serverService.deleteServer(server);
+        serverService.delete(server);
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -54,6 +54,7 @@ public class ServerFacade {
     private final ChannelServiceImpl channelService;
     private final ServerMemberServiceImpl serverMemberService;
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public ServerCreateResponseDto createServer(ServerCreateRequestDto requestDto) {
         //서버 생성
@@ -242,6 +243,7 @@ public class ServerFacade {
         server.updateServerImg(s3Util.uploadImage(newImage, "server"));
     }
 
+    /* TODO @crHwang0822 리팩토링 */
     @Transactional
     public void delegateServerRole(Long serverId, ServerRoleDelegateRequestDto requestDto) {
         Server server = serverService.getServerById(serverId);

--- a/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/facade/ServerFacade.java
@@ -28,6 +28,7 @@ import org.bookwoori.core.domain.server.dto.response.ServerListResponseDto;
 import org.bookwoori.core.domain.server.dto.response.ServerMemberListResponseDto;
 import org.bookwoori.core.domain.server.entity.Server;
 import org.bookwoori.core.domain.server.service.ServerServiceImpl;
+import org.bookwoori.core.domain.serverMember.entity.ServerMember;
 import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 import org.bookwoori.core.domain.serverMember.service.ServerMemberServiceImpl;
 import org.bookwoori.core.global.exception.CustomException;
@@ -55,17 +56,21 @@ public class ServerFacade {
 
     @Transactional
     public ServerCreateResponseDto createServer(ServerCreateRequestDto requestDto) {
-        //서버 저장
+        //서버 생성
         Server server = requestDto.toEntity(
             s3Util.uploadImage(requestDto.serverImg(), "server"));
         serverService.save(server);
 
-        //로그인한 유저 정보 불러오기 - 임시로 작성, 이후 수정 필요
-        Member member = memberService.getCurrentMember();
-        //서버장을 ServerMember 테이블에 추가
-        serverMemberService.save(member, server, ServerRole.OWNER);
+        //서버장 생성
+        Member currentMember = memberService.getCurrentMember();
+        ServerMember serverMember = ServerMember.builder()
+            .server(server)
+            .member(currentMember)
+            .role(ServerRole.OWNER)
+            .build();
+        serverMemberService.save(serverMember);
 
-        //DEFAULT 카테고리/채널 생성 및 저장
+        //기본 카테고리 및 채널 생성
         Category category = categoryService.makeDefaultCategory(server);
         channelService.makeDefaultChannels(category);
         return ServerCreateResponseDto.from(server);
@@ -181,8 +186,13 @@ public class ServerFacade {
         if (isJoined) {
             throw new CustomException(ErrorCode.ALREADY_JOINED_SERVER);
         } else {
-            serverMemberService.save(currentMember, server,
-                ServerRole.MEMBER); // 서버멤버 생성
+            // 서버멤버 생성
+            ServerMember serverMember = ServerMember.builder()
+                .server(server)
+                .member(currentMember)
+                .role(ServerRole.MEMBER)
+                .build();
+            serverMemberService.save(serverMember);
         }
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/service/ServerService.java
@@ -1,5 +1,12 @@
 package org.bookwoori.core.domain.server.service;
 
+import org.bookwoori.core.domain.server.entity.Server;
+
 public interface ServerService {
 
+    Server save(Server server);
+
+    void delete(Server server);
+
+    Server getServerById(Long serverId);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/server/service/ServerServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/server/service/ServerServiceImpl.java
@@ -14,11 +14,11 @@ public class ServerServiceImpl implements ServerService {
 
     private final ServerRepository serverRepository;
 
-    public Server saveServer(Server server) {
+    public Server save(Server server) {
         return serverRepository.save(server);
     }
 
-    public void deleteServer(Server server) {
+    public void delete(Server server) {
         serverRepository.delete(server);
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -1,5 +1,33 @@
 package org.bookwoori.core.domain.serverMember.service;
 
+import java.util.List;
+import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.server.entity.Server;
+import org.bookwoori.core.domain.serverMember.dto.ServerMemberDto;
+import org.bookwoori.core.domain.serverMember.entity.ServerMember;
+import org.bookwoori.core.domain.serverMember.entity.ServerRole;
+
 public interface ServerMemberService {
 
+    ServerMember save(Member member, Server server, ServerRole role);
+
+    boolean isJoined(Member member, Server server);
+
+    boolean isOwner(Member member, Server server);
+
+    Member getOwner(Server server);
+
+    int getMemberCount(Server server);
+
+    List<ServerMemberDto> getAllMembersByServer(Server server);
+
+    List<Server> getServerListByMember(Member member);
+
+    void delete(Server server, Member member);
+
+    ServerMember getByMemberAndServer(Member member, Server server);
+
+    void delegateServerRole(Server server, Member from, Member to);
+
+    List<Server> getAllByMemberAndRole(Member currentMember, ServerRole serverRole);
 }

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberService.java
@@ -9,7 +9,7 @@ import org.bookwoori.core.domain.serverMember.entity.ServerRole;
 
 public interface ServerMemberService {
 
-    ServerMember save(Member member, Server server, ServerRole role);
+    ServerMember save(ServerMember serverMember);
 
     boolean isJoined(Member member, Server server);
 

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberServiceImpl.java
@@ -20,12 +20,7 @@ public class ServerMemberServiceImpl implements ServerMemberService {
 
     private final ServerMemberRepository serverMemberRepository;
 
-    public ServerMember save(Member member, Server server, ServerRole role) {
-        ServerMember serverMember = ServerMember.builder()
-            .member(member)
-            .server(server)
-            .role(role)
-            .build();
+    public ServerMember save(ServerMember serverMember) {
         return serverMemberRepository.save(serverMember);
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberServiceImpl.java
+++ b/core/src/main/java/org/bookwoori/core/domain/serverMember/service/ServerMemberServiceImpl.java
@@ -20,13 +20,13 @@ public class ServerMemberServiceImpl implements ServerMemberService {
 
     private final ServerMemberRepository serverMemberRepository;
 
-    public void saveServerMember(Member member, Server server, ServerRole role) {
+    public ServerMember save(Member member, Server server, ServerRole role) {
         ServerMember serverMember = ServerMember.builder()
             .member(member)
             .server(server)
             .role(role)
             .build();
-        serverMemberRepository.save(serverMember);
+        return serverMemberRepository.save(serverMember);
     }
 
     @Transactional(readOnly = true)
@@ -63,7 +63,7 @@ public class ServerMemberServiceImpl implements ServerMemberService {
             .map(ServerMember::getServer).toList();
     }
 
-    public void deleteServerMember(Server server, Member member) {
+    public void delete(Server server, Member member) {
         serverMemberRepository.deleteByServerAndMember(server, member);
     }
 

--- a/core/src/main/java/org/bookwoori/core/global/util/RedisUtil.java
+++ b/core/src/main/java/org/bookwoori/core/global/util/RedisUtil.java
@@ -1,0 +1,23 @@
+package org.bookwoori.core.global.util;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValuesWithTimeout(String key, String value, Duration timeout) {
+        redisTemplate.opsForValue().set(key, value, timeout);
+    }
+
+    @Transactional(readOnly = true)
+    public Object getValues(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+}

--- a/core/src/main/java/org/bookwoori/core/global/util/S3Util.java
+++ b/core/src/main/java/org/bookwoori/core/global/util/S3Util.java
@@ -1,4 +1,4 @@
-package org.bookwoori.core.global.s3;
+package org.bookwoori.core.global.util;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;


### PR DESCRIPTION
## 🛠️ PR 요약
  - 서비스 인터페이스 작성
  - 파사드 의존성 관련 코드 수정
  - 서비스/파사드 메서드 리팩토링
  - `RedisUtil` 클래스 구현

## 📝 작업 상세
  - 서비스 계층 메서드 rename: `save~` → `save` / `delete~` → `delete`
  - `S3Util` 클래스 move: `global/s3` → `global/util`
  - serverMemberService 의 `save` 메서드 리팩토링: 파라미터를 `serverMember` 타입으로 변경
  - serverFacade 에서 리턴 타입이 `Object` 였던 메서드들의 리턴 타입을 정확히 명시해주었습니다. @minseoooooo 
  - serverFacade 에서 `redisTemplate` 을 의존하지 않고, `RedisUtil` 을 의존하도록 코드를 변경했습니다. @minseoooooo 

## 🗣️ 공유 사항
1. 서비스 계층 메서드의 리턴 타입을 entity 로 제한하는 게 좋을까요?
    > 현재는 서비스 계층의 메서드 중에 DTO를 반환하는 것도 있는 것으로 아는데 (ex. ServerMemberService의 `getAllMembersByServer`) , 서비스 계층 메서드의 리턴 타입을 entity 로 제한하고 DTO로 변환하는 게 필요할 시 해당 책임은 파사드 계층으로 넘기는 게 좋을지 고민입니닷
2. 파사드 계층에서 서비스 인터페이스를 의존하도록 수정했어야 했는데 제가 놓쳤었네요 .., 지금은 구현 클래스를 의존받도록 되어있는데, 다음 PR 올리실 때 해당 부분 꼭 수정 부탁드립니다! (일단 충돌 우려 때문에 제가 맡은 도메인 부분만 수정해놨습니다)

## 🎯 Resolve
  - #134 
