### PR TITLE
[Feat] QA 테스트 후 백엔드 수정사항 반영 

### DIFF
--- a/core/src/main/java/org/bookwoori/core/domain/book/facade/BookFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/book/facade/BookFacade.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.book.facade;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -18,7 +19,14 @@ public class BookFacade {
 
     @Transactional(readOnly = true)
     public List<BookResponseDto> getBooksByKeyword(String keyword) {
-        return bookService.getBooksByKeyword(keyword);
+        List<BookResponseDto> bookList = bookService.getBooksByKeyword(keyword);
+        List<BookResponseDto> filteredBooks = new ArrayList<>();
+        for (BookResponseDto book : bookList) {
+            if (book.isbn13() != null && !book.isbn13().isEmpty()) {
+                filteredBooks.add(book);
+            }
+        }
+        return filteredBooks;
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelCreateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelCreateRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import org.bookwoori.core.domain.book.entity.Book;
-import org.bookwoori.core.domain.climbing.dto.validation.ValidDateRange;
+import org.bookwoori.core.global.validation.ValidDateRange;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
 import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.server.entity.Server;

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelUpdateRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/request/ClimbingChannelUpdateRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import org.bookwoori.core.domain.climbing.dto.validation.ValidDateRange;
+import org.bookwoori.core.global.validation.ValidDateRange;
 
 @ValidDateRange
 public record ClimbingChannelUpdateRequestDto(

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/dto/validation/DateValidator.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/dto/validation/DateValidator.java
@@ -5,63 +5,42 @@ import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalDate;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
+
 
 public class DateValidator implements ConstraintValidator<ValidDateRange, Object> {
 
     @Override
     public boolean isValid(Object obj, ConstraintValidatorContext context) {
         LocalDate today = LocalDate.now();
-        LocalDate minDate = today.plusDays(1); // 최소 기준 날짜 (당일 + 1)
+        LocalDate minDate = today.plusDays(1); // 최소 기준 날짜 (오늘 + 1)
 
         if (obj instanceof ClimbingChannelCreateRequestDto dto) {
-            // startDate가 최소 기준 이후인지 확인
-            if (dto.startDate().isBefore(minDate)) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-시작 날짜는 최소 현재 날짜의 다음 날 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            // startDate가 오늘 이후인지 확인
+            if (!dto.startDate().isAfter(today)) {
+                throw new CustomException(ErrorCode.INVALID_START_DATE);
             }
-            // endDate가 최소 기준 이후인지 확인
-            if (dto.endDate().isBefore(minDate)) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-종료 날짜는 최소 현재 날짜의 다음 날 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            // endDate가 오늘 이후인지 확인
+            if (!dto.endDate().isAfter(today)) {
+                throw new CustomException(ErrorCode.INVALID_END_DATE);
             }
             // endDate가 startDate 이후인지 확인
-            if (dto.endDate().isBefore(dto.startDate())) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-종료 날짜는 시작 날짜 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            if (!dto.endDate().isAfter(dto.startDate())) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_DATE);
             }
         } else if (obj instanceof ClimbingChannelUpdateRequestDto dto) {
-            // startDate가 최소 기준 이후인지 확인
-            if (dto.startDate().isBefore(minDate)) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-시작 날짜는 최소 현재 날짜의 다음 날 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            // startDate가 오늘 이후인지 확인
+            if (!dto.startDate().isAfter(today)) {
+                throw new CustomException(ErrorCode.INVALID_START_DATE);
             }
-            // endDate가 최소 기준 이후인지 확인
-            if (dto.endDate().isBefore(minDate)) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-종료 날짜는 최소 현재 날짜의 다음 날 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            // endDate가 오늘 이후인지 확인
+            if (!dto.endDate().isAfter(today)) {
+                throw new CustomException(ErrorCode.INVALID_END_DATE);
             }
             // endDate가 startDate 이후인지 확인
-            if (dto.endDate().isBefore(dto.startDate())) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(
-                        "INVALID_INPUT_DATE-종료 날짜는 시작 날짜 이후여야 합니다.")
-                    .addConstraintViolation();
-                return false;
+            if (!dto.endDate().isAfter(dto.startDate())) {
+                throw new CustomException(ErrorCode.INVALID_INPUT_DATE);
             }
         }
         return true;

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -2,11 +2,9 @@ package org.bookwoori.core.domain.climbing.facade;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.book.entity.Book;
-import org.bookwoori.core.domain.record.entity.Record;
 import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
@@ -92,7 +90,7 @@ public class ClimbingFacade {
     private void updateEndClimbingMemberFinalData(Climbing climbing, List<ClimbingMember> climbingMemberList){
         for (ClimbingMember member : climbingMemberList) {
             recordService.getRecordOptByMemberAndBook(member.getMember(), climbing.getBook())
-                .ifPresent(record -> member.updateFinalDate(record.getMaxPage(), record.getStatus()));
+                .ifPresent(record -> member.updateFinalData(record.getMaxPage(), record.getStatus()));
         }
     }
 

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingFacade.java
@@ -2,9 +2,11 @@ package org.bookwoori.core.domain.climbing.facade;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bookwoori.core.domain.book.entity.Book;
+import org.bookwoori.core.domain.record.entity.Record;
 import org.bookwoori.core.domain.book.service.BookService;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
@@ -75,15 +77,23 @@ public class ClimbingFacade {
                 else {
                     climbing.updateStatus(ClimbingStatus.FAILED);
                 }
+                // 클라이밍 종료 시점의 climbingMember 데이터 저장
+                updateEndClimbingMemberFinalData(climbing, climbingMemberList);
             }
             climbingService.saveClimbingChannel(climbing);
         }
     }
 
-    @Transactional
     @GrantExp(type = ExpType.FINISHED_CLIMBING)
     public void updateFinishedClimbingStatus(Climbing climbing){
         climbing.updateStatus(ClimbingStatus.FINISHED);
+    }
+
+    private void updateEndClimbingMemberFinalData(Climbing climbing, List<ClimbingMember> climbingMemberList){
+        for (ClimbingMember member : climbingMemberList) {
+            recordService.getRecordOptByMemberAndBook(member.getMember(), climbing.getBook())
+                .ifPresent(record -> member.updateFinalDate(record.getMaxPage(), record.getStatus()));
+        }
     }
 
     public void createClimbing(ClimbingChannelCreateRequestDto requestDto) {

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingMemberFacade.java
@@ -22,6 +22,7 @@ import org.bookwoori.core.domain.climbing.dto.response.ReviewEmojiListDto;
 import org.bookwoori.core.domain.climbing.dto.response.ReviewEmojiMemberListResponseDto;
 import org.bookwoori.core.domain.climbing.dto.response.ReviewEmojiMemberUnitDto;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.climbing.service.ClimbingService;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingMember;
 import org.bookwoori.core.domain.climbingMember.entity.ClimbingRole;
@@ -87,9 +88,16 @@ public class ClimbingMemberFacade {
             .map(member -> {
                 Optional<Record> record = recordService.getClimbingMemberRecordOpt(member,
                     climbing.getBook());
-                ReadingStatus status = record.map(Record::getStatus).orElse(ReadingStatus.UNREAD);
                 boolean isMine = member.getMember().equals(currentMember);
-                int currentPage = record.map(Record::getCurrentPage).orElse(0);
+                ReadingStatus status;
+                int currentPage;
+                if(climbing.getStatus() != ClimbingStatus.FAILED && climbing.getStatus() != ClimbingStatus.FINISHED){
+                    status = record.map(Record::getStatus).orElse(ReadingStatus.UNREAD);
+                    currentPage = record.map(Record::getCurrentPage).orElse(0);
+                } else {
+                    status = member.getFinalStatus();
+                    currentPage = member.getFinalPage();
+                }
                 return ClimbingMemberUnitDto.from(isMine, member, status, currentPage);
             })
             .collect(Collectors.toList());

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
@@ -79,7 +79,7 @@ public class ClimbingReviewFacade {
     List<Review> reviews = climbingReviews.stream()
         .map(ClimbingReview::getReview)
         .collect(Collectors.toList());
-    
+
     // 리뷰가 있을 때만 이모지 데이터 조회
     List<ReviewEmoji> sharedReviewEmojis = reviews.isEmpty()
         ? Collections.emptyList()
@@ -122,6 +122,4 @@ public class ClimbingReviewFacade {
 
     return new ClimbingReviewListResponseDto(true, climbingMemberReviewUnits);
   }
-
-
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
@@ -79,11 +79,11 @@ public class ClimbingReviewFacade {
     List<Review> reviews = climbingReviews.stream()
         .map(ClimbingReview::getReview)
         .collect(Collectors.toList());
-
+    
     // 리뷰가 있을 때만 이모지 데이터 조회
     List<ReviewEmoji> sharedReviewEmojis = reviews.isEmpty()
         ? Collections.emptyList()
-        : reviewEmojiService.getEmojisByClimbingAndReviews(climbing, reviews);
+        : reviewEmojiService.getEmojisByReviews(reviews);
 
     // 리뷰 ID 기준으로 이모지 그룹화
     Map<Long, Map<EmojiType, Long>> reviewEmojiCounts = sharedReviewEmojis.stream()

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
@@ -69,7 +69,7 @@ public class ClimbingReviewFacade {
     List<ClimbingReview> climbingReviews = sharedClimbingMemberIds.stream()
         .map(climbingReviewService::findByClimbingMemberId)
         .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .toList();
 
     if (climbingReviews.isEmpty()) {
       return new ClimbingReviewListResponseDto(true, Collections.emptyList());
@@ -114,8 +114,8 @@ public class ClimbingReviewFacade {
                 ))
                 .collect(Collectors.toList());
 
-//            ClimbingMember climbingMember = climbingMemberService.getClimbingMemberWithMember(climbingId, memberId);
-            Member member = memberService.getMemberById(memberId);
+            ClimbingMember climbingMember = climbingMemberService.getClimbingMemberWithMember(climbingId, memberId);
+            Member member = memberService.getMemberById(climbingMember.getMember().getMemberId());
             return ClimbingMemberReviewUnitDto.from(member, review, reviewEmojiList);
           }).orElse(null);
         })

--- a/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbing/facade/ClimbingReviewFacade.java
@@ -105,7 +105,6 @@ public class ClimbingReviewFacade {
           return climbingReviewOpt.map(climbingReview -> {
             Review review = climbingReview.getReview();
             Map<EmojiType, Long> emojiCounts = reviewEmojiCounts.getOrDefault(review.getReviewId(), Collections.emptyMap());
-
             List<ReviewEmojiListCountDto> reviewEmojiList = emojiCounts.entrySet().stream()
                 .map(entry -> new ReviewEmojiListCountDto(
                     reviewEmojiService.hasClickedEmoji(review, memberService.getCurrentMember(), entry.getKey()),
@@ -114,8 +113,7 @@ public class ClimbingReviewFacade {
                 ))
                 .collect(Collectors.toList());
 
-            ClimbingMember climbingMember = climbingMemberService.getClimbingMemberWithMember(climbingId, memberId);
-            Member member = memberService.getMemberById(climbingMember.getMember().getMemberId());
+            Member member = climbingMemberService.getClimbingMemberById(memberId).getMember();
             return ClimbingMemberReviewUnitDto.from(member, review, reviewEmojiList);
           }).orElse(null);
         })

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
@@ -18,7 +18,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
+import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.member.entity.Member;
+import org.bookwoori.core.domain.record.entity.ReadingStatus;
 
 @Entity
 @Table(name = "climbing_member")
@@ -55,12 +57,20 @@ public class ClimbingMember {
     @NotNull
     private ClimbingRole role;
 
+    @Column(name = "final_page")
+    private int finalPage;
+
+    @Column(name = "final_status")
+    private ReadingStatus finalStatus;
+
     public ClimbingMember(Member member, Climbing climbing, ClimbingRole role) {
         this.member = member;
         this.climbing = climbing;
         this.role = role;
         this.hasShared = false;
         this.memo = null;
+        this.finalPage = 0;
+        this.finalStatus = ReadingStatus.UNREAD;
     }
 
     public void updateMemo(String memo) {
@@ -73,5 +83,10 @@ public class ClimbingMember {
 
     public void updateShared(boolean hasShared) {
         this.hasShared = hasShared;
+    }
+
+    public void updateFinalDate(int maxPage, ReadingStatus status) {
+        this.finalPage = maxPage;
+        this.finalStatus = status;
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/entity/ClimbingMember.java
@@ -18,7 +18,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.bookwoori.core.domain.climbing.entity.Climbing;
-import org.bookwoori.core.domain.climbing.entity.ClimbingStatus;
 import org.bookwoori.core.domain.member.entity.Member;
 import org.bookwoori.core.domain.record.entity.ReadingStatus;
 
@@ -85,7 +84,7 @@ public class ClimbingMember {
         this.hasShared = hasShared;
     }
 
-    public void updateFinalDate(int maxPage, ReadingStatus status) {
+    public void updateFinalData(int maxPage, ReadingStatus status) {
         this.finalPage = maxPage;
         this.finalStatus = status;
     }

--- a/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/climbingMember/service/ClimbingMemberService.java
@@ -82,4 +82,12 @@ public class ClimbingMemberService {
     public List<Long> getSharedClimbingMemberIds(Climbing climbing) {
         return climbingMemberRepository.findSharedClimbingMemberIdsByClimbing(climbing);
     }
+
+    @Transactional(readOnly = true)
+    public ClimbingMember getClimbingMemberById(Long climbingMemberId){
+        return climbingMemberRepository.findById(climbingMemberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CLIMBING_MEMBER_NOT_FOUND));
+    }
+
+
 }

--- a/core/src/main/java/org/bookwoori/core/domain/exp/controller/ExpController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/exp/controller/ExpController.java
@@ -14,12 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Tag(name = "Exp")
 @RequiredArgsConstructor
-@RequestMapping("/explog")
+@RequestMapping("/expLog")
 public class ExpController {
 
   private final ExpFacade expFacade;
 
-  @Operation(summary = "경험지 기록 목록 조회", description = "경험지 기록 목록을 조회합니다.")
+  @Operation(summary = "경험치 기록 목록 조회", description = "경험치 기록 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<?> getExpLogs() {
     return ResponseEntity.ok(expFacade.getExpLogs());

--- a/core/src/main/java/org/bookwoori/core/domain/member/entity/Grade.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/entity/Grade.java
@@ -20,7 +20,8 @@ public enum Grade {
     Mudeungsan(4, "무등산", 997),
     Bukhansan(3, "북한산", 727),
     Achasan(2, "아차산", 296),
-    Dongsan(1, "동산", 100);
+    Dongsan(1, "동산", 100),
+    Flatland(0, "평지", 0);
 
     private final int level;
     private final String mountain;
@@ -41,6 +42,6 @@ public enum Grade {
                 return grade;
             }
         }
-        return Grade.Dongsan;
+        return Grade.Flatland;
     }
 }

--- a/core/src/main/java/org/bookwoori/core/domain/member/entity/Member.java
+++ b/core/src/main/java/org/bookwoori/core/domain/member/entity/Member.java
@@ -66,7 +66,7 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.profileImg = profileImg;
         this.backgroundImg = null;
-        this.grade = Grade.Dongsan;
+        this.grade = Grade.Flatland;
         this.status = Status.ACTIVE;
         this.totalPage = 0;
         this.totalHeight = 0;

--- a/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
@@ -1,5 +1,6 @@
 package org.bookwoori.core.domain.record.dto.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -11,6 +12,8 @@ import org.bookwoori.core.domain.record.entity.ReadingStatus;
 import org.bookwoori.core.domain.record.entity.Record;
 import org.bookwoori.core.domain.review.dto.response.ReviewUnitDto;
 import org.bookwoori.core.domain.review.entity.Review;
+import org.bookwoori.core.global.exception.CustomException;
+import org.bookwoori.core.global.exception.ErrorCode;
 
 
 public record RecordRequestDto(
@@ -25,6 +28,9 @@ public record RecordRequestDto(
 ) {
 
     public Record toRecordEntity(Member currentMember, Book book) {
+        if (currentPage > book.getItemPage()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_PAGE);
+        }
         return Record.builder()
             .member(currentMember)
             .book(book)

--- a/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
@@ -31,14 +31,26 @@ public record RecordRequestDto(
         if (currentPage > book.getItemPage()) {
             throw new CustomException(ErrorCode.INVALID_INPUT_PAGE);
         }
-        return Record.builder()
-            .member(currentMember)
-            .book(book)
-            .status(status)
-            .startDate(startDate)
-            .endDate(endDate)
-            .currentPage(currentPage)
-            .build();
+        else if(status == ReadingStatus.FINISHED){
+            return Record.builder()
+                .member(currentMember)
+                .book(book)
+                .status(status)
+                .startDate(startDate)
+                .endDate(endDate)
+                .currentPage(book.getItemPage())
+                .build();
+        }
+        else {
+            return Record.builder()
+                .member(currentMember)
+                .book(book)
+                .status(status)
+                .startDate(startDate)
+                .endDate(endDate)
+                .currentPage(currentPage)
+                .build();
+        }
     }
 
 }

--- a/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
@@ -14,8 +14,9 @@ import org.bookwoori.core.domain.review.dto.response.ReviewUnitDto;
 import org.bookwoori.core.domain.review.entity.Review;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
+import org.bookwoori.core.global.validation.ValidDateRange;
 
-
+@ValidDateRange
 public record RecordRequestDto(
     @NotBlank
     @Size(min = 13, max = 13)

--- a/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/record/dto/request/RecordRequestDto.java
@@ -31,6 +31,9 @@ public record RecordRequestDto(
         if (currentPage > book.getItemPage()) {
             throw new CustomException(ErrorCode.INVALID_INPUT_PAGE);
         }
+        else if(status == ReadingStatus.UNREAD){
+            throw new CustomException(ErrorCode.INVALID_ENUM_VALUE);
+        }
         else if(status == ReadingStatus.FINISHED){
             return Record.builder()
                 .member(currentMember)

--- a/core/src/main/java/org/bookwoori/core/domain/review/controller/ReviewController.java
+++ b/core/src/main/java/org/bookwoori/core/domain/review/controller/ReviewController.java
@@ -41,7 +41,7 @@ public class ReviewController {
   }
 
   @Operation(summary = "책 감상평 삭제", description = "수정 페이지_책기록 에서 기존 감상평을 삭제합니다.")
-  @DeleteMapping
+  @DeleteMapping("/{reviewId}")
   public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
     reviewFacade.deleteReview(reviewId);
     return ResponseEntity.ok().build();

--- a/core/src/main/java/org/bookwoori/core/domain/review/dto/request/ReviewRequestDto.java
+++ b/core/src/main/java/org/bookwoori/core/domain/review/dto/request/ReviewRequestDto.java
@@ -1,10 +1,14 @@
 package org.bookwoori.core.domain.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.bookwoori.core.domain.record.entity.Record;
 import org.bookwoori.core.domain.review.entity.Review;
 
 public record ReviewRequestDto(
     Long recordId,
+    @Min(0)
+    @Max(5)
     int star,
     String content
 ) {

--- a/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/entity/EmojiType.java
+++ b/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/entity/EmojiType.java
@@ -5,11 +5,11 @@ import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 
 public enum EmojiType {
-    GOOD,
-    HEART,
-    SMILE,
-    CRY,
-    THINK;
+    THUMBS_UP,
+    HEART_HANDS,
+    SMILING_FACE,
+    CRYING_FACE,
+    THINKING_FACE;
 
     @JsonCreator
     public static EmojiType from(String s) {

--- a/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/repository/ReviewEmojiRepository.java
+++ b/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/repository/ReviewEmojiRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewEmojiRepository extends JpaRepository<ReviewEmoji, Long> {
 
-    List<ReviewEmoji> findByClimbingAndReviewIn(Climbing climbing, List<Review> sharedReviews);
+    List<ReviewEmoji> findByReviewIn(List<Review> sharedReviews);
 
     Optional<ReviewEmoji> findByMemberAndClimbingAndReviewAndEmoji(Member member, Climbing climbing,
         Review review, EmojiType emoji);

--- a/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/service/ReviewEmojiService.java
+++ b/core/src/main/java/org/bookwoori/core/domain/reviewEmoji/service/ReviewEmojiService.java
@@ -30,9 +30,8 @@ public class ReviewEmojiService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReviewEmoji> getEmojisByClimbingAndReviews(Climbing climbing,
-        List<Review> sharedReviews) {
-        return reviewEmojiRepository.findByClimbingAndReviewIn(climbing, sharedReviews);
+    public List<ReviewEmoji> getEmojisByReviews(List<Review> sharedReviews) {
+        return reviewEmojiRepository.findByReviewIn(sharedReviews);
     }
 
     @Transactional(readOnly = true)

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
     OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
     CLIMBING_MEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
     CLIMBING_NOT_RUNNING(409, 3405, "진행 중인 클라이밍이 아닙니다."),
+    INVALID_START_DATE(400, 3406, "시작 날짜는 최소 오늘 이후여야 합니다."),
+    INVALID_END_DATE(400, 3407, "종료 날짜는 최소 오늘 이후여야 합니다."),
+    INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜 이후여야 합니다."),
+
 
     // Book (3500 ~ 3599)
     BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),
@@ -82,7 +86,9 @@ public enum ErrorCode {
     ALREADY_EXIST_REVIEW(409, 3703, "이미 레코드에 대한 리뷰가 존재합니다."),
 
     // MessageRoom (3800 ~ 3899)
-    MESSAGE_ROOM_NOT_FOUND(404, 3800, "채팅방을 찾을 수 없습니다.");
+    MESSAGE_ROOM_NOT_FOUND(404, 3800, "채팅방을 찾을 수 없습니다."),
+
+    ;
 
     private final int status;
     private final int code;

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -78,9 +78,9 @@ public enum ErrorCode {
     RECORD_NOT_FOUND(404, 3600, "레코드를 찾을 수 없습니다."),
     RECORD_NOT_FINISHED(409, 3601, "다 읽은 책이 아닙니다."),
     ALREADY_EXIST_RECORD(409, 3602, "이미 존재하는 레코드입니다."),
-    RECORD_INVALID_START_DATE(400, 3406, "시작 날짜는 오늘 이전이어야 합니다."),
-    RECORD_INVALID_END_DATE(400, 3407, "종료 날짜는 오늘 이전이어야 합니다."),
-    RECORD_INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜와 같거나 이후여야 합니다."),
+    RECORD_INVALID_START_DATE(400, 3606, "시작 날짜는 오늘 이전이어야 합니다."),
+    RECORD_INVALID_END_DATE(400, 3607, "종료 날짜는 오늘 이전이어야 합니다."),
+    RECORD_INVALID_INPUT_DATE(400, 3608, "종료 날짜는 시작 날짜와 같거나 이후여야 합니다."),
 
     // Review (3700 ~ 3799)
     REVIEW_NOT_FOUND(404, 3700, "리뷰를 찾을 수 없습니다."),

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -65,9 +65,9 @@ public enum ErrorCode {
     OWNER_CANNOT_LEAVE(409, 3403, "OWNER는 클라이밍 채널을 떠날 수 없습니다."),
     CLIMBING_MEMBER_NOT_FOUND(404, 3404, "클라이밍 멤버를 찾을 수 없습니다."),
     CLIMBING_NOT_RUNNING(409, 3405, "진행 중인 클라이밍이 아닙니다."),
-    INVALID_START_DATE(400, 3406, "시작 날짜는 최소 오늘 이후여야 합니다."),
-    INVALID_END_DATE(400, 3407, "종료 날짜는 최소 오늘 이후여야 합니다."),
-    INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜 이후여야 합니다."),
+    CLIMBING_INVALID_START_DATE(400, 3406, "시작 날짜는 최소 오늘 이후여야 합니다."),
+    CLIMBING_INVALID_END_DATE(400, 3407, "종료 날짜는 최소 오늘 이후여야 합니다."),
+    CLIMBING_INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜 이후여야 합니다."),
 
     // Book (3500 ~ 3599)
     BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),
@@ -78,6 +78,9 @@ public enum ErrorCode {
     RECORD_NOT_FOUND(404, 3600, "레코드를 찾을 수 없습니다."),
     RECORD_NOT_FINISHED(409, 3601, "다 읽은 책이 아닙니다."),
     ALREADY_EXIST_RECORD(409, 3602, "이미 존재하는 레코드입니다."),
+    RECORD_INVALID_START_DATE(400, 3406, "시작 날짜는 오늘 이전이어야 합니다."),
+    RECORD_INVALID_END_DATE(400, 3407, "종료 날짜는 오늘 이전이어야 합니다."),
+    RECORD_INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜와 같거나 이후여야 합니다."),
 
     // Review (3700 ~ 3799)
     REVIEW_NOT_FOUND(404, 3700, "리뷰를 찾을 수 없습니다."),

--- a/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/ErrorCode.java
@@ -69,10 +69,10 @@ public enum ErrorCode {
     INVALID_END_DATE(400, 3407, "종료 날짜는 최소 오늘 이후여야 합니다."),
     INVALID_INPUT_DATE(400, 3408, "종료 날짜는 시작 날짜 이후여야 합니다."),
 
-
     // Book (3500 ~ 3599)
     BOOK_NOT_FOUND(404, 3500, "책을 찾을 수 없습니다."),
     ALADIN_API_EXCEPTION(404, 3501, "알라딘 API 호출에 실패했습니다."),
+    INVALID_INPUT_PAGE(400, 3502, "책의 최대 페이지를 초과할 수 없습니다."),
 
     // Record (3600 ~ 3699)
     RECORD_NOT_FOUND(404, 3600, "레코드를 찾을 수 없습니다."),

--- a/core/src/main/java/org/bookwoori/core/global/exception/GlobalExceptionHandler.java
+++ b/core/src/main/java/org/bookwoori/core/global/exception/GlobalExceptionHandler.java
@@ -30,21 +30,18 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
     }
 
-    @ExceptionHandler({BindException.class, MethodArgumentNotValidException.class})
-    protected ResponseEntity<ErrorDto> handleValidationException(Exception e,
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    protected ResponseEntity<ErrorDto> handleValidationException(MethodArgumentNotValidException e,
         HttpServletRequest request) {
-        BindingResult bindingResult = null;
+        BindingResult bindingResult = e.getBindingResult();
+        String errorMessage = "Validation error";
 
-        if (e instanceof BindException) {
-            bindingResult = ((BindException) e).getBindingResult();
-        } else if (e instanceof MethodArgumentNotValidException) {
-            bindingResult = ((MethodArgumentNotValidException) e).getBindingResult();
+        if (bindingResult.hasErrors()) {
+            FieldError fieldError = bindingResult.getFieldError();
+            if (fieldError != null) {
+                errorMessage = fieldError.getDefaultMessage();
+            }
         }
-        FieldError fieldError = bindingResult != null ? bindingResult.getFieldError() : null;
-
-        String errorMessage = fieldError != null
-            ? fieldError.getField() + ": " + fieldError.getDefaultMessage()
-            : "Validation error";
 
         ErrorDto errorDto = ErrorDto.builder()
             .timestamp(LocalDateTime.now().toString())
@@ -54,7 +51,6 @@ public class GlobalExceptionHandler {
             .path(request.getRequestURI())
             .build();
 
-        return new ResponseEntity<>(errorDto,
-            HttpStatusCode.valueOf(ErrorCode.BAD_REQUEST.getStatus()));
+        return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf((ErrorCode.BAD_REQUEST.getStatus())));
     }
 }

--- a/core/src/main/java/org/bookwoori/core/global/validation/DateValidator.java
+++ b/core/src/main/java/org/bookwoori/core/global/validation/DateValidator.java
@@ -1,10 +1,11 @@
-package org.bookwoori.core.domain.climbing.dto.validation;
+package org.bookwoori.core.global.validation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.time.LocalDate;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelCreateRequestDto;
 import org.bookwoori.core.domain.climbing.dto.request.ClimbingChannelUpdateRequestDto;
+import org.bookwoori.core.domain.record.dto.request.RecordRequestDto;
 import org.bookwoori.core.global.exception.CustomException;
 import org.bookwoori.core.global.exception.ErrorCode;
 
@@ -14,33 +15,45 @@ public class DateValidator implements ConstraintValidator<ValidDateRange, Object
     @Override
     public boolean isValid(Object obj, ConstraintValidatorContext context) {
         LocalDate today = LocalDate.now();
-        LocalDate minDate = today.plusDays(1); // 최소 기준 날짜 (오늘 + 1)
 
         if (obj instanceof ClimbingChannelCreateRequestDto dto) {
             // startDate가 오늘 이후인지 확인
             if (!dto.startDate().isAfter(today)) {
-                throw new CustomException(ErrorCode.INVALID_START_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_START_DATE);
             }
             // endDate가 오늘 이후인지 확인
             if (!dto.endDate().isAfter(today)) {
-                throw new CustomException(ErrorCode.INVALID_END_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_END_DATE);
             }
             // endDate가 startDate 이후인지 확인
             if (!dto.endDate().isAfter(dto.startDate())) {
-                throw new CustomException(ErrorCode.INVALID_INPUT_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_INPUT_DATE);
             }
         } else if (obj instanceof ClimbingChannelUpdateRequestDto dto) {
             // startDate가 오늘 이후인지 확인
             if (!dto.startDate().isAfter(today)) {
-                throw new CustomException(ErrorCode.INVALID_START_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_START_DATE);
             }
             // endDate가 오늘 이후인지 확인
             if (!dto.endDate().isAfter(today)) {
-                throw new CustomException(ErrorCode.INVALID_END_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_END_DATE);
             }
             // endDate가 startDate 이후인지 확인
             if (!dto.endDate().isAfter(dto.startDate())) {
-                throw new CustomException(ErrorCode.INVALID_INPUT_DATE);
+                throw new CustomException(ErrorCode.CLIMBING_INVALID_INPUT_DATE);
+            }
+        } else if (obj instanceof RecordRequestDto dto) {
+            // startDate가 오늘 이전인지 확인
+            if (dto.startDate() != null && !dto.startDate().isBefore(today) && !dto.startDate().isEqual(today)) {
+                throw new CustomException(ErrorCode.RECORD_INVALID_START_DATE);
+            }
+            // endDate가 오늘 이전인지 확인
+            if (dto.endDate() != null && !dto.endDate().isBefore(today) && !dto.endDate().isEqual(today)) {
+                throw new CustomException(ErrorCode.RECORD_INVALID_END_DATE);
+            }
+            // startDate가 endDate보다 이전인지 확인 (같은 날짜도 가능)
+            if (dto.startDate() != null && dto.endDate() != null && dto.startDate().isAfter(dto.endDate())) {
+                throw new CustomException(ErrorCode.RECORD_INVALID_INPUT_DATE);
             }
         }
         return true;

--- a/core/src/main/java/org/bookwoori/core/global/validation/ValidDateRange.java
+++ b/core/src/main/java/org/bookwoori/core/global/validation/ValidDateRange.java
@@ -1,4 +1,4 @@
-package org.bookwoori.core.domain.climbing.dto.validation;
+package org.bookwoori.core.global.validation;
 
 
 import jakarta.validation.Constraint;


### PR DESCRIPTION
## 🛠️ PR 요약
  - 책 감상평 삭제 API 오류 수정
  - 클라이밍 채널 감상평 리스트 조회 API 오류 수정
  - ReviewEmoji의 EmojiType ENUM 통일
  - 책 검색 API isbn이 존재하는 책 데이터만 반환
  - 멤버 생성 시 Grade 0, Flatland(평지) 부여 
  - DateValidator가 Custom 에러 던지도록 수정 
  - Climbing 종료 시점의 ClimbingMember 데이터 저장하도록 수정 
  - 책 감상평 추가/편집 API 
    - 별점 validation 추가
    - 책 페이지 이상의 currentPage 에러 처리
    - ReadingStatus FINISHED의 경우 currentPage=book의 itemPage
    - ReadingStatus UNREAD 선택 불가능
    - Date에 대한 Validation 추가


## 🎯 Resolve
